### PR TITLE
feat: independent service configurations

### DIFF
--- a/src/pytest_databases/docker/__init__.py
+++ b/src/pytest_databases/docker/__init__.py
@@ -130,25 +130,3 @@ class DockerServiceRegistry:
     def down(self) -> None:
         if not SKIP_DOCKER_COMPOSE:
             self.run_command("down", "-t", "10")
-
-
-@pytest.fixture(scope="session")
-def compose_project_name() -> str:
-    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
-
-
-@pytest.fixture(scope="session")
-def docker_services(compose_project_name: str, worker_id: str = "main") -> Generator[DockerServiceRegistry, None, None]:
-    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
-        pytest.skip("Docker not available on this platform")
-
-    registry = DockerServiceRegistry(worker_id, compose_project_name=compose_project_name)
-    try:
-        yield registry
-    finally:
-        registry.down()
-
-
-@pytest.fixture(scope="session")
-def docker_ip(docker_services: DockerServiceRegistry) -> str:
-    return docker_services.docker_ip

--- a/src/pytest_databases/docker/alloydb_omni.py
+++ b/src/pytest_databases/docker/alloydb_omni.py
@@ -24,14 +24,21 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import asyncpg
 import pytest
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-alloydb-{simple_string_hash(__file__)}"
 
 
 async def alloydb_omni_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
@@ -53,54 +60,78 @@ async def alloydb_omni_responsive(host: str, port: int, user: str, password: str
         await conn.close()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def alloydb_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def alloydb_docker_services(
+    alloydb_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=alloydb_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def postgres_user() -> str:
     return "postgres"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres_database() -> str:
     return "postgres"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def alloydb_omni_port() -> int:
     return 5420
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def default_alloydb_omni_service_name() -> str:
     return "alloydb"
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def alloydb_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.alloydb-omni.yml")]
 
 
+@pytest.fixture(scope="session")
+def alloydb_docker_ip(alloydb_docker_services: DockerServiceRegistry) -> str:
+    return alloydb_docker_services.docker_ip
+
+
 # alias to the latest
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def alloydb_omni_service(
-    docker_services: DockerServiceRegistry,
+    alloydb_docker_services: DockerServiceRegistry,
     default_alloydb_omni_service_name: str,
-    docker_compose_files: list[Path],
+    alloydb_docker_compose_files: list[Path],
     alloydb_omni_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ[f"{default_alloydb_omni_service_name.upper()}_PORT"] = str(alloydb_omni_port)
-    await docker_services.start(
+    await alloydb_docker_services.start(
         name=default_alloydb_omni_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=alloydb_docker_compose_files,
         timeout=45,
         pause=1,
         check=alloydb_omni_responsive,
@@ -109,3 +140,4 @@ async def alloydb_omni_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield

--- a/src/pytest_databases/docker/bigquery.py
+++ b/src/pytest_databases/docker/bigquery.py
@@ -24,16 +24,23 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import AnonymousCredentials, Credentials
 from google.cloud import bigquery
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-bigquery-{simple_string_hash(__file__)}"
 
 
 async def bigquery_responsive(
@@ -57,43 +64,57 @@ async def bigquery_responsive(
         return False
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
+def bigquery_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def bigquery_docker_services(
+    bigquery_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=bigquery_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def bigquery_port() -> int:
     return 9051
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def bigquery_grpc_port() -> int:
     return 9061
 
 
-@pytest.fixture
-def bigquery_endpoint(docker_ip: str, bigquery_port: int) -> str:
-    return f"http://{docker_ip}:{bigquery_port}"
-
-
-@pytest.fixture
+@pytest.fixture(scope="session")
 def bigquery_dataset() -> str:
     return "test-dataset"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def bigquery_project() -> str:
     return "emulator-test-project"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def bigquery_client_options(bigquery_endpoint: str) -> ClientOptions:
     return ClientOptions(api_endpoint=bigquery_endpoint)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def bigquery_credentials() -> Credentials:
     return AnonymousCredentials()
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def bigquery_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.bigquery.yml")]
 
 
@@ -102,11 +123,21 @@ def default_bigquery_service_name() -> str:
     return "bigquery"
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def bigquery_docker_ip(bigquery_docker_services: DockerServiceRegistry) -> str:
+    return bigquery_docker_services.docker_ip
+
+
+@pytest.fixture(scope="session")
+def bigquery_endpoint(bigquery_docker_ip: str, bigquery_port: int) -> str:
+    return f"http://{bigquery_docker_ip}:{bigquery_port}"
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def bigquery_service(
-    docker_services: DockerServiceRegistry,
+    bigquery_docker_services: DockerServiceRegistry,
     default_bigquery_service_name: str,
-    docker_compose_files: list[Path],
+    bigquery_docker_compose_files: list[Path],
     bigquery_port: int,
     bigquery_grpc_port: int,
     bigquery_endpoint: str,
@@ -114,15 +145,15 @@ async def bigquery_service(
     bigquery_project: str,
     bigquery_credentials: Credentials,
     bigquery_client_options: ClientOptions,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["BIGQUERY_ENDPOINT"] = bigquery_endpoint
     os.environ["BIGQUERY_DATASET"] = bigquery_dataset
     os.environ["BIGQUERY_PORT"] = str(bigquery_port)
     os.environ["BIGQUERY_GRPC_PORT"] = str(bigquery_grpc_port)
     os.environ["GOOGLE_CLOUD_PROJECT"] = bigquery_project
-    await docker_services.start(
+    await bigquery_docker_services.start(
         name=default_bigquery_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=bigquery_docker_compose_files,
         timeout=60,
         check=bigquery_responsive,
         bigquery_endpoint=bigquery_endpoint,
@@ -131,3 +162,4 @@ async def bigquery_service(
         bigquery_credentials=bigquery_credentials,
         bigquery_client_options=bigquery_client_options,
     )
+    yield

--- a/src/pytest_databases/docker/dragonfly.py
+++ b/src/pytest_databases/docker/dragonfly.py
@@ -24,15 +24,21 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-dragonfly-{simple_string_hash(__file__)}"
 
 
 async def dragonfly_responsive(host: str, port: int) -> bool:
@@ -45,13 +51,32 @@ async def dragonfly_responsive(host: str, port: int) -> bool:
         await client.aclose()  # type: ignore[attr-defined]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def dragonfly_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def dragonfly_docker_services(
+    dragonfly_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=dragonfly_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def dragonfly_port() -> int:
     return 6398
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def dragonfly_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.dragonfly.yml")]
 
 
@@ -60,17 +85,23 @@ def default_dragonfly_service_name() -> str:
     return "dragonfly"
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def dragonfly_docker_ip(dragonfly_docker_services: DockerServiceRegistry) -> str:
+    return dragonfly_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def dragonfly_service(
-    docker_services: DockerServiceRegistry,
+    dragonfly_docker_services: DockerServiceRegistry,
     default_dragonfly_service_name: str,
-    docker_compose_files: list[Path],
+    dragonfly_docker_compose_files: list[Path],
     dragonfly_port: int,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["DRAGONFLY_PORT"] = str(dragonfly_port)
-    await docker_services.start(
+    await dragonfly_docker_services.start(
         name=default_dragonfly_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=dragonfly_docker_compose_files,
         check=dragonfly_responsive,
         port=dragonfly_port,
     )
+    yield

--- a/src/pytest_databases/docker/keydb.py
+++ b/src/pytest_databases/docker/keydb.py
@@ -24,15 +24,22 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-keydb-{simple_string_hash(__file__)}"
 
 
 async def keydb_responsive(host: str, port: int) -> bool:
@@ -45,13 +52,32 @@ async def keydb_responsive(host: str, port: int) -> bool:
         await client.aclose()  # type: ignore[attr-defined]
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=False, scope="session")
+def keydb_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(scope="session")
+def keydb_docker_services(
+    keydb_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=keydb_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def keydb_port() -> int:
     return 6396
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def keydb_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.keydb.yml")]
 
 
@@ -60,17 +86,23 @@ def default_keydb_service_name() -> str:
     return "keydb"
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def keydb_docker_ip(keydb_docker_services: DockerServiceRegistry) -> str:
+    return keydb_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def keydb_service(
-    docker_services: DockerServiceRegistry,
+    keydb_docker_services: DockerServiceRegistry,
     default_keydb_service_name: str,
-    docker_compose_files: list[Path],
+    keydb_docker_compose_files: list[Path],
     keydb_port: int,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["KEYDB_PORT"] = str(keydb_port)
-    await docker_services.start(
+    await keydb_docker_services.start(
         name=default_keydb_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=keydb_docker_compose_files,
         check=keydb_responsive,
         port=keydb_port,
     )
+    yield

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -25,14 +25,21 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import asyncmy
 import pytest
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-mariadb-{simple_string_hash(__file__)}"
 
 
 async def mariadb_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
@@ -57,64 +64,88 @@ async def mariadb_responsive(host: str, port: int, user: str, password: str, dat
             await conn.close()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def mariadb_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mariadb_docker_services(
+    mariadb_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=mariadb_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def mariadb_user() -> str:
     return "app"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mariadb_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mariadb_root_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mariadb_database() -> str:
     return "db"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mariadb113_port() -> int:
     return 3359
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def default_mariadb_service_name() -> str:
     return "mariadb113"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mariadb_port(mariadb113_port: int) -> int:
     return mariadb113_port
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def mariadb_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.mariadb.yml")]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def mariadb_docker_ip(mariadb_docker_services: DockerServiceRegistry) -> str:
+    return mariadb_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def mariadb113_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    mariadb_docker_services: DockerServiceRegistry,
+    mariadb_docker_compose_files: list[Path],
     mariadb113_port: int,
     mariadb_database: str,
     mariadb_user: str,
     mariadb_password: str,
     mariadb_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MARIADB_ROOT_PASSWORD"] = mariadb_root_password
     os.environ["MARIADB_PASSWORD"] = mariadb_password
     os.environ["MARIADB_USER"] = mariadb_user
     os.environ["MARIADB_DATABASE"] = mariadb_database
     os.environ["MARIADB113_PORT"] = str(mariadb113_port)
-    await docker_services.start(
+    await mariadb_docker_services.start(
         "mariadb113",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mariadb_docker_compose_files,
         timeout=45,
         pause=1,
         check=mariadb_responsive,
@@ -123,27 +154,28 @@ async def mariadb113_service(
         user=mariadb_user,
         password=mariadb_password,
     )
+    yield
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=False, scope="session")
 async def mariadb_service(
-    docker_services: DockerServiceRegistry,
+    mariadb_docker_services: DockerServiceRegistry,
     default_mariadb_service_name: str,
-    docker_compose_files: list[Path],
+    mariadb_docker_compose_files: list[Path],
     mariadb_port: int,
     mariadb_database: str,
     mariadb_user: str,
     mariadb_password: str,
     mariadb_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MARIADB_ROOT_PASSWORD"] = mariadb_root_password
     os.environ["MARIADB_PASSWORD"] = mariadb_password
     os.environ["MARIADB_USER"] = mariadb_user
     os.environ["MARIADB_DATABASE"] = mariadb_database
     os.environ[f"{default_mariadb_service_name.upper()}_PORT"] = str(mariadb_port)
-    await docker_services.start(
+    await mariadb_docker_services.start(
         name=default_mariadb_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mariadb_docker_compose_files,
         timeout=45,
         pause=1,
         check=mariadb_responsive,
@@ -152,3 +184,4 @@ async def mariadb_service(
         user=mariadb_user,
         password=mariadb_password,
     )
+    yield

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -25,14 +25,21 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import asyncmy
 import pytest
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-mysql-{simple_string_hash(__file__)}"
 
 
 async def mysql_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
@@ -57,74 +64,98 @@ async def mysql_responsive(host: str, port: int, user: str, password: str, datab
             await conn.close()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def mysql_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mysql_docker_services(
+    mysql_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=mysql_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def mysql_user() -> str:
     return "app"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql_root_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql_database() -> str:
     return "db"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql56_port() -> int:
     return 3362
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql57_port() -> int:
     return 3361
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def default_mysql_service_name() -> str:
     return "mysql8"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql8_port() -> int:
     return 3360
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def mysql_port(mysql8_port: int) -> int:
     return mysql8_port
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def mysql_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.mysql.yml")]
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def mysql_docker_ip(mysql_docker_services: DockerServiceRegistry) -> str:
+    return mysql_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def mysql8_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    mysql_docker_services: DockerServiceRegistry,
+    mysql_docker_compose_files: list[Path],
     mysql8_port: int,
     mysql_database: str,
     mysql_user: str,
     mysql_password: str,
     mysql_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MYSQL_ROOT_PASSWORD"] = mysql_root_password
     os.environ["MYSQL_PASSWORD"] = mysql_password
     os.environ["MYSQL_USER"] = mysql_user
     os.environ["MYSQL_DATABASE"] = mysql_database
     os.environ["MYSQL8_PORT"] = str(mysql8_port)
-    await docker_services.start(
+    await mysql_docker_services.start(
         "mysql8",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mysql_docker_compose_files,
         timeout=45,
         pause=1,
         check=mysql_responsive,
@@ -133,26 +164,27 @@ async def mysql8_service(
         user=mysql_user,
         password=mysql_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def mysql57_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    mysql_docker_services: DockerServiceRegistry,
+    mysql_docker_compose_files: list[Path],
     mysql57_port: int,
     mysql_database: str,
     mysql_user: str,
     mysql_password: str,
     mysql_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MYSQL_ROOT_PASSWORD"] = mysql_root_password
     os.environ["MYSQL_PASSWORD"] = mysql_password
     os.environ["MYSQL_USER"] = mysql_user
     os.environ["MYSQL_DATABASE"] = mysql_database
     os.environ["MYSQL57_PORT"] = str(mysql57_port)
-    await docker_services.start(
+    await mysql_docker_services.start(
         "mysql57",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mysql_docker_compose_files,
         timeout=45,
         pause=1,
         check=mysql_responsive,
@@ -161,26 +193,27 @@ async def mysql57_service(
         user=mysql_user,
         password=mysql_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def mysql56_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    mysql_docker_services: DockerServiceRegistry,
+    mysql_docker_compose_files: list[Path],
     mysql56_port: int,
     mysql_database: str,
     mysql_user: str,
     mysql_password: str,
     mysql_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MYSQL_ROOT_PASSWORD"] = mysql_root_password
     os.environ["MYSQL_PASSWORD"] = mysql_password
     os.environ["MYSQL_USER"] = mysql_user
     os.environ["MYSQL_DATABASE"] = mysql_database
     os.environ["MYSQL56_PORT"] = str(mysql56_port)
-    await docker_services.start(
+    await mysql_docker_services.start(
         "mysql56",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mysql_docker_compose_files,
         timeout=45,
         pause=1,
         check=mysql_responsive,
@@ -189,27 +222,28 @@ async def mysql56_service(
         user=mysql_user,
         password=mysql_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def mysql_service(
-    docker_services: DockerServiceRegistry,
+    mysql_docker_services: DockerServiceRegistry,
     default_mysql_service_name: str,
-    docker_compose_files: list[Path],
+    mysql_docker_compose_files: list[Path],
     mysql_port: int,
     mysql_database: str,
     mysql_user: str,
     mysql_password: str,
     mysql_root_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["MYSQL_ROOT_PASSWORD"] = mysql_root_password
     os.environ["MYSQL_PASSWORD"] = mysql_password
     os.environ["MYSQL_USER"] = mysql_user
     os.environ["MYSQL_DATABASE"] = mysql_database
     os.environ[f"{default_mysql_service_name.upper()}_PORT"] = str(mysql_port)
-    await docker_services.start(
+    await mysql_docker_services.start(
         name=default_mysql_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=mysql_docker_compose_files,
         timeout=45,
         pause=1,
         check=mysql_responsive,
@@ -218,3 +252,4 @@ async def mysql_service(
         user=mysql_user,
         password=mysql_password,
     )
+    yield

--- a/src/pytest_databases/docker/oracle.py
+++ b/src/pytest_databases/docker/oracle.py
@@ -24,14 +24,21 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import oracledb
 import pytest
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-oracle-{simple_string_hash(__file__)}"
 
 
 def oracle_responsive(host: str, port: int, service_name: str, user: str, password: str) -> bool:
@@ -51,79 +58,103 @@ def oracle_responsive(host: str, port: int, service_name: str, user: str, passwo
         return False
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def oracle_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def oracle_docker_services(
+    oracle_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=oracle_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def oracle_user() -> str:
     return "app"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle_system_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle18c_service_name() -> str:
     return "xepdb1"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle23c_service_name() -> str:
     return "FREEPDB1"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle_service_name(oracle23c_service_name: str) -> str:
     return oracle23c_service_name
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle18c_port() -> int:
     return 1514
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle23c_port() -> int:
     return 1513
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def default_oracle_service_name() -> str:
     return "oracle23c"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def oracle_port(oracle23c_port: int) -> int:
     return oracle23c_port
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def oracle_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.oracle.yml")]
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def oracle_docker_ip(oracle_docker_services: DockerServiceRegistry) -> str:
+    return oracle_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def oracle23c_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    oracle_docker_services: DockerServiceRegistry,
+    oracle_docker_compose_files: list[Path],
     oracle23c_port: int,
     oracle23c_service_name: str,
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE23C_SERVICE_NAME"] = oracle23c_service_name
     os.environ["ORACLE23C_PORT"] = str(oracle23c_port)
-    await docker_services.start(
+    await oracle_docker_services.start(
         "oracle23c",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=oracle_docker_compose_files,
         timeout=90,
         pause=1,
         check=oracle_responsive,
@@ -132,26 +163,27 @@ async def oracle23c_service(
         user=oracle_user,
         password=oracle_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def oracle18c_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    oracle_docker_services: DockerServiceRegistry,
+    oracle_docker_compose_files: list[Path],
     oracle18c_port: int,
     oracle18c_service_name: str,
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE18C_SERVICE_NAME"] = oracle18c_service_name
     os.environ["ORACLE18C_PORT"] = str(oracle18c_port)
-    await docker_services.start(
+    await oracle_docker_services.start(
         "oracle18c",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=oracle_docker_compose_files,
         timeout=90,
         pause=1,
         check=oracle_responsive,
@@ -160,28 +192,29 @@ async def oracle18c_service(
         user=oracle_user,
         password=oracle_password,
     )
+    yield
 
 
 # alias to the latest
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def oracle_service(
-    docker_services: DockerServiceRegistry,
+    oracle_docker_services: DockerServiceRegistry,
     default_oracle_service_name: str,
-    docker_compose_files: list[Path],
+    oracle_docker_compose_files: list[Path],
     oracle_port: int,
     oracle_service_name: str,
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE_SERVICE_NAME"] = oracle_service_name
     os.environ[f"{default_oracle_service_name.upper()}_PORT"] = str(oracle_port)
-    await docker_services.start(
+    await oracle_docker_services.start(
         name=default_oracle_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=oracle_docker_compose_files,
         timeout=90,
         pause=1,
         check=oracle_responsive,
@@ -190,3 +223,4 @@ async def oracle_service(
         user=oracle_user,
         password=oracle_password,
     )
+    yield

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -24,14 +24,21 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import asyncpg
 import pytest
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-postgres-{simple_string_hash(__file__)}"
 
 
 async def postgres_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
@@ -53,82 +60,106 @@ async def postgres_responsive(host: str, port: int, user: str, password: str, da
         await conn.close()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def postgres_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def postgres_docker_services(
+    postgres_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=postgres_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def postgres_user() -> str:
     return "postgres"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres_password() -> str:
     return "super-secret"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres_database() -> str:
     return "postgres"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres11_port() -> int:
     return 5422
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres12_port() -> int:
     return 5423
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres13_port() -> int:
     return 5424
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres14_port() -> int:
     return 5425
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres15_port() -> int:
     return 5426
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres16_port() -> int:
     return 5427
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def default_postgres_service_name() -> str:
     return "postgres16"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def postgres_port(postgres16_port: int) -> int:
     return postgres16_port
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def postgres_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.postgres.yml")]
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def postgres_docker_ip(postgres_docker_services: DockerServiceRegistry) -> str:
+    return postgres_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def postgres12_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    postgres_docker_services: DockerServiceRegistry,
+    postgres_docker_compose_files: list[Path],
     postgres12_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES12_PORT"] = str(postgres12_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         "postgres12",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -137,24 +168,25 @@ async def postgres12_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def postgres13_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    postgres_docker_services: DockerServiceRegistry,
+    postgres_docker_compose_files: list[Path],
     postgres13_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES13_PORT"] = str(postgres13_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         "postgres13",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -163,24 +195,25 @@ async def postgres13_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def postgres14_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    postgres_docker_services: DockerServiceRegistry,
+    postgres_docker_compose_files: list[Path],
     postgres14_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES14_PORT"] = str(postgres14_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         "postgres14",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -189,24 +222,25 @@ async def postgres14_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def postgres15_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    postgres_docker_services: DockerServiceRegistry,
+    postgres_docker_compose_files: list[Path],
     postgres15_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES15_PORT"] = str(postgres15_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         "postgres15",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -215,24 +249,25 @@ async def postgres15_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def postgres16_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    postgres_docker_services: DockerServiceRegistry,
+    postgres_docker_compose_files: list[Path],
     postgres16_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES16_PORT"] = str(postgres16_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         "postgres16",
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -241,26 +276,27 @@ async def postgres16_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield
 
 
 # alias to the latest
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, scope="session")
 async def postgres_service(
-    docker_services: DockerServiceRegistry,
+    postgres_docker_services: DockerServiceRegistry,
     default_postgres_service_name: str,
-    docker_compose_files: list[Path],
+    postgres_docker_compose_files: list[Path],
     postgres_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ[f"{default_postgres_service_name.upper()}_PORT"] = str(postgres_port)
-    await docker_services.start(
+    await postgres_docker_services.start(
         name=default_postgres_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=postgres_docker_compose_files,
         timeout=45,
         pause=1,
         check=postgres_responsive,
@@ -269,3 +305,4 @@ async def postgres_service(
         user=postgres_user,
         password=postgres_password,
     )
+    yield

--- a/src/pytest_databases/docker/redis.py
+++ b/src/pytest_databases/docker/redis.py
@@ -24,15 +24,22 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
+from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.helpers import simple_string_hash
+
 if TYPE_CHECKING:
-    from pytest_databases.docker import DockerServiceRegistry
+    from collections.abc import Generator
+
+
+COMPOSE_PROJECT_NAME: str = f"pytest-databases-redis-{simple_string_hash(__file__)}"
 
 
 async def redis_responsive(host: str, port: int) -> bool:
@@ -45,13 +52,32 @@ async def redis_responsive(host: str, port: int) -> bool:
         await client.aclose()  # type: ignore[attr-defined]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def redis_compose_project_name() -> str:
+    return os.environ.get("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT_NAME)
+
+
+@pytest.fixture(autouse=False, scope="session")
+def redis_docker_services(
+    redis_compose_project_name: str, worker_id: str = "main"
+) -> Generator[DockerServiceRegistry, None, None]:
+    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+        pytest.skip("Docker not available on this platform")
+
+    registry = DockerServiceRegistry(worker_id, compose_project_name=redis_compose_project_name)
+    try:
+        yield registry
+    finally:
+        registry.down()
+
+
+@pytest.fixture(scope="session")
 def redis_port() -> int:
     return 6397
 
 
 @pytest.fixture(scope="session")
-def docker_compose_files() -> list[Path]:
+def redis_docker_compose_files() -> list[Path]:
     return [Path(Path(__file__).parent / "docker-compose.redis.yml")]
 
 
@@ -60,17 +86,23 @@ def default_redis_service_name() -> str:
     return "redis"
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="session")
+def redis_docker_ip(redis_docker_services: DockerServiceRegistry) -> str:
+    return redis_docker_services.docker_ip
+
+
+@pytest.fixture(autouse=False, scope="session")
 async def redis_service(
-    docker_services: DockerServiceRegistry,
+    redis_docker_services: DockerServiceRegistry,
     default_redis_service_name: str,
-    docker_compose_files: list[Path],
+    redis_docker_compose_files: list[Path],
     redis_port: int,
-) -> None:
+) -> AsyncGenerator[None, None]:
     os.environ["REDIS_PORT"] = str(redis_port)
-    await docker_services.start(
+    await redis_docker_services.start(
         name=default_redis_service_name,
-        docker_compose_files=docker_compose_files,
+        docker_compose_files=redis_docker_compose_files,
         check=redis_responsive,
         port=redis_port,
     )
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,6 @@ pytest_plugins = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def anyio_backend() -> str:
     return "asyncio"

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -52,7 +52,7 @@ async def test_alloydb_omni_default_config(
 
 
 async def test_alloydb_omni_services(
-    docker_ip: str,
+    alloydb_docker_ip: str,
     alloydb_omni_service: DockerServiceRegistry,
     alloydb_omni_port: int,
     postgres_database: str,
@@ -60,7 +60,7 @@ async def test_alloydb_omni_services(
     postgres_password: str,
 ) -> None:
     ping = await alloydb_omni_responsive(
-        docker_ip,
+        alloydb_docker_ip,
         port=alloydb_omni_port,
         database=postgres_database,
         user=postgres_user,

--- a/tests/docker/test_bigquery.py
+++ b/tests/docker/test_bigquery.py
@@ -41,7 +41,7 @@ pytest_plugins = [
 
 
 def test_bigquery_default_config(
-    docker_ip: str,
+    bigquery_docker_ip: str,
     bigquery_port: int,
     bigquery_grpc_port: int,
     bigquery_dataset: str,
@@ -51,12 +51,12 @@ def test_bigquery_default_config(
     assert bigquery_port == 9051
     assert bigquery_grpc_port == 9061
     assert bigquery_dataset == "test-dataset"
-    assert bigquery_endpoint == f"http://{docker_ip}:9051"
+    assert bigquery_endpoint == f"http://{bigquery_docker_ip}:9051"
     assert bigquery_project == "emulator-test-project"
 
 
 async def test_bigquery_services(
-    docker_ip: str,
+    bigquery_docker_ip: str,
     bigquery_service: DockerServiceRegistry,
     bigquery_endpoint: str,
     bigquery_dataset: str,
@@ -65,7 +65,7 @@ async def test_bigquery_services(
     bigquery_credentials: Credentials,
 ) -> None:
     ping = await bigquery_responsive(
-        docker_ip,
+        bigquery_docker_ip,
         bigquery_endpoint=bigquery_endpoint,
         bigquery_dataset=bigquery_dataset,
         bigquery_project=bigquery_project,

--- a/tests/docker/test_cockroachdb.py
+++ b/tests/docker/test_cockroachdb.py
@@ -47,11 +47,13 @@ def test_cockroachdb_default_config(
 
 
 async def test_cockroachdb_service(
-    docker_ip: str,
+    cockroachdb_docker_ip: str,
     cockroachdb_service: DockerServiceRegistry,
     cockroachdb_database: str,
     cockroachdb_port: int,
     cockroachdb_driver_opts: dict[str, str],
 ) -> None:
-    ping = await cockroachdb_responsive(docker_ip, cockroachdb_port, cockroachdb_database, cockroachdb_driver_opts)
+    ping = await cockroachdb_responsive(
+        cockroachdb_docker_ip, cockroachdb_port, cockroachdb_database, cockroachdb_driver_opts
+    )
     assert ping

--- a/tests/docker/test_dragonfly.py
+++ b/tests/docker/test_dragonfly.py
@@ -43,9 +43,9 @@ def test_dragonfly_default_config(dragonfly_port: int) -> None:
 
 
 async def test_dragonfly_service(
-    docker_ip: str,
+    dragonfly_docker_ip: str,
     dragonfly_service: DockerServiceRegistry,
     dragonfly_port: int,
 ) -> None:
-    ping = await dragonfly_responsive(docker_ip, dragonfly_port)
+    ping = await dragonfly_responsive(dragonfly_docker_ip, dragonfly_port)
     assert ping

--- a/tests/docker/test_elasticsearch.py
+++ b/tests/docker/test_elasticsearch.py
@@ -45,8 +45,8 @@ pytest_plugins = [
 
 @pytest.fixture
 async def elasticsearch7_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    elasticsearch_docker_services: DockerServiceRegistry,
+    elasticsearch_docker_compose_files: list[Path],
     elasticsearch7_port: int,
     elasticsearch_database: str,
     elasticsearch_user: str,
@@ -55,9 +55,9 @@ async def elasticsearch7_service(
 ) -> AsyncGenerator[Any, Any]:
     """Overwrites fixture to stop container after the test."""
     try:
-        await docker_services.start(
+        await elasticsearch_docker_services.start(
             "elasticsearch7",
-            docker_compose_files=docker_compose_files,
+            docker_compose_files=elasticsearch_docker_compose_files,
             timeout=45,
             pause=1,
             check=elasticsearch7_responsive,
@@ -69,13 +69,13 @@ async def elasticsearch7_service(
         )
         yield
     finally:
-        docker_services.stop("elasticsearch7")
+        elasticsearch_docker_services.stop("elasticsearch7")
 
 
 @pytest.fixture
 async def elasticsearch8_service(
-    docker_services: DockerServiceRegistry,
-    docker_compose_files: list[Path],
+    elasticsearch_docker_services: DockerServiceRegistry,
+    elasticsearch_docker_compose_files: list[Path],
     elasticsearch8_port: int,
     elasticsearch_database: str,
     elasticsearch_user: str,
@@ -84,9 +84,9 @@ async def elasticsearch8_service(
 ) -> AsyncGenerator[Any, Any]:
     """Overwrites fixture to stop container after the test."""
     try:
-        await docker_services.start(
+        await elasticsearch_docker_services.start(
             "elasticsearch8",
-            docker_compose_files=docker_compose_files,
+            docker_compose_files=elasticsearch_docker_compose_files,
             timeout=45,
             pause=1,
             check=elasticsearch8_responsive,
@@ -98,7 +98,7 @@ async def elasticsearch8_service(
         )
         yield
     finally:
-        docker_services.stop("elasticsearch8")
+        elasticsearch_docker_services.stop("elasticsearch8")
 
 
 def test_elasticsearch7_default_config(
@@ -120,7 +120,7 @@ def test_elasticsearch8_default_config(
 
 
 async def test_elasticsearch7_service(
-    docker_ip: str,
+    elasticsearch_docker_ip: str,
     elasticsearch7_service: DockerServiceRegistry,
     elasticsearch7_port: str,
     elasticsearch_user: str,
@@ -128,7 +128,7 @@ async def test_elasticsearch7_service(
     elasticsearch_scheme: str,
 ) -> None:
     async with Elasticsearch7(
-        hosts=[{"host": docker_ip, "port": elasticsearch7_port, "scheme": elasticsearch_scheme}],
+        hosts=[{"host": elasticsearch_docker_ip, "port": elasticsearch7_port, "scheme": elasticsearch_scheme}],
         verify_certs=False,
         http_auth=(elasticsearch_user, elasticsearch_password),
     ) as client:
@@ -138,7 +138,7 @@ async def test_elasticsearch7_service(
 
 
 async def test_elasticsearch8_service(
-    docker_ip: str,
+    elasticsearch_docker_ip: str,
     elasticsearch8_service: DockerServiceRegistry,
     elasticsearch8_port: str,
     elasticsearch_user: str,
@@ -146,7 +146,7 @@ async def test_elasticsearch8_service(
     elasticsearch_scheme: str,
 ) -> None:
     async with Elasticsearch8(
-        hosts=[{"host": docker_ip, "port": elasticsearch8_port, "scheme": elasticsearch_scheme}],
+        hosts=[{"host": elasticsearch_docker_ip, "port": elasticsearch8_port, "scheme": elasticsearch_scheme}],
         verify_certs=False,
         basic_auth=(elasticsearch_user, elasticsearch_password),
     ) as client:

--- a/tests/docker/test_keydb.py
+++ b/tests/docker/test_keydb.py
@@ -43,9 +43,9 @@ def test_keydb_default_config(keydb_port: int) -> None:
 
 
 async def test_keydb_service(
-    docker_ip: str,
+    keydb_docker_ip: str,
     keydb_service: DockerServiceRegistry,
     keydb_port: int,
 ) -> None:
-    ping = await keydb_responsive(docker_ip, keydb_port)
+    ping = await keydb_responsive(keydb_docker_ip, keydb_port)
     assert ping

--- a/tests/docker/test_mariadb.py
+++ b/tests/docker/test_mariadb.py
@@ -64,7 +64,7 @@ async def test_mariadb_113_config(
 
 
 async def test_mariadb_services(
-    docker_ip: str,
+    mariadb_docker_ip: str,
     mariadb_service: DockerServiceRegistry,
     mariadb_port: int,
     mariadb_database: str,
@@ -72,7 +72,7 @@ async def test_mariadb_services(
     mariadb_password: str,
 ) -> None:
     ping = await mariadb_responsive(
-        docker_ip,
+        mariadb_docker_ip,
         port=mariadb_port,
         database=mariadb_database,
         user=mariadb_user,
@@ -82,7 +82,7 @@ async def test_mariadb_services(
 
 
 async def test_mariadb_113_services(
-    docker_ip: str,
+    mariadb_docker_ip: str,
     mariadb113_service: DockerServiceRegistry,
     mariadb113_port: int,
     mariadb_database: str,
@@ -90,7 +90,7 @@ async def test_mariadb_113_services(
     mariadb_password: str,
 ) -> None:
     ping = await mariadb_responsive(
-        docker_ip,
+        mariadb_docker_ip,
         port=mariadb113_port,
         database=mariadb_database,
         user=mariadb_user,

--- a/tests/docker/test_mssql.py
+++ b/tests/docker/test_mssql.py
@@ -85,28 +85,28 @@ async def test_mssql_2022_config(
 
 
 async def test_mssql_services(
-    docker_ip: str,
+    mssql_docker_ip: str,
     mssql_service: DockerServiceRegistry,
     mssql_port: int,
     mssql_database: str,
     mssql_user: str,
     mssql_password: str,
 ) -> None:
-    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={docker_ip},{mssql_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
+    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
 
-    ping = await mssql_responsive(docker_ip, connstring=connstring)
+    ping = await mssql_responsive(mssql_docker_ip, connstring=connstring)
     assert ping
 
 
 async def test_mssql_2022_services(
-    docker_ip: str,
+    mssql_docker_ip: str,
     mssql2022_service: DockerServiceRegistry,
     mssql2022_port: int,
     mssql_database: str,
     mssql_user: str,
     mssql_password: str,
 ) -> None:
-    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={docker_ip},{mssql2022_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
+    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql2022_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
 
-    ping = await mssql_responsive(docker_ip, connstring=connstring)
+    ping = await mssql_responsive(mssql_docker_ip, connstring=connstring)
     assert ping

--- a/tests/docker/test_mysql.py
+++ b/tests/docker/test_mysql.py
@@ -88,7 +88,7 @@ async def test_mysql_56_config(
 
 
 async def test_mysql_services(
-    docker_ip: str,
+    mysql_docker_ip: str,
     mysql_service: DockerServiceRegistry,
     mysql_port: int,
     mysql_database: str,
@@ -96,7 +96,7 @@ async def test_mysql_services(
     mysql_password: str,
 ) -> None:
     ping = await mysql_responsive(
-        docker_ip,
+        mysql_docker_ip,
         port=mysql_port,
         database=mysql_database,
         user=mysql_user,
@@ -106,7 +106,7 @@ async def test_mysql_services(
 
 
 async def test_mysql_57_services(
-    docker_ip: str,
+    mysql_docker_ip: str,
     mysql57_service: DockerServiceRegistry,
     mysql57_port: int,
     mysql_database: str,
@@ -114,7 +114,7 @@ async def test_mysql_57_services(
     mysql_password: str,
 ) -> None:
     ping = await mysql_responsive(
-        docker_ip,
+        mysql_docker_ip,
         port=mysql57_port,
         database=mysql_database,
         user=mysql_user,
@@ -124,7 +124,7 @@ async def test_mysql_57_services(
 
 
 async def test_mysql_56_services(
-    docker_ip: str,
+    mysql_docker_ip: str,
     mysql56_service: DockerServiceRegistry,
     mysql56_port: int,
     mysql_database: str,
@@ -132,7 +132,7 @@ async def test_mysql_56_services(
     mysql_password: str,
 ) -> None:
     ping = await mysql_responsive(
-        docker_ip,
+        mysql_docker_ip,
         port=mysql56_port,
         database=mysql_database,
         user=mysql_user,
@@ -142,7 +142,7 @@ async def test_mysql_56_services(
 
 
 async def test_mysql_8_services(
-    docker_ip: str,
+    mysql_docker_ip: str,
     mysql8_service: DockerServiceRegistry,
     mysql8_port: int,
     mysql_database: str,
@@ -150,7 +150,7 @@ async def test_mysql_8_services(
     mysql_password: str,
 ) -> None:
     ping = await mysql_responsive(
-        docker_ip,
+        mysql_docker_ip,
         port=mysql8_port,
         database=mysql_database,
         user=mysql_user,

--- a/tests/docker/test_oracle.py
+++ b/tests/docker/test_oracle.py
@@ -72,7 +72,7 @@ def test_oracle_default_config(
 
 
 async def test_oracle18c_service(
-    docker_ip: str,
+    oracle_docker_ip: str,
     oracle18c_service: DockerServiceRegistry,
     oracle18c_service_name: str,
     oracle18c_port: int,
@@ -80,7 +80,9 @@ async def test_oracle18c_service(
     oracle_password: str,
 ) -> None:
     conn = oracledb.connect(
-        user=oracle_user, password=oracle_password, dsn=f"{docker_ip}:{oracle18c_port!s}/{oracle18c_service_name}"
+        user=oracle_user,
+        password=oracle_password,
+        dsn=f"{oracle_docker_ip}:{oracle18c_port!s}/{oracle18c_service_name}",
     )
     with conn.cursor() as cur:
         cur.execute("SELECT 'Hello World!' FROM dual")
@@ -89,7 +91,7 @@ async def test_oracle18c_service(
 
 
 async def test_oracle23c_service(
-    docker_ip: str,
+    oracle_docker_ip: str,
     oracle23c_service: DockerServiceRegistry,
     oracle23c_service_name: str,
     oracle23c_port: int,
@@ -97,7 +99,9 @@ async def test_oracle23c_service(
     oracle_password: str,
 ) -> None:
     conn = oracledb.connect(
-        user=oracle_user, password=oracle_password, dsn=f"{docker_ip}:{oracle23c_port!s}/{oracle23c_service_name}"
+        user=oracle_user,
+        password=oracle_password,
+        dsn=f"{oracle_docker_ip}:{oracle23c_port!s}/{oracle23c_service_name}",
     )
     with conn.cursor() as cur:
         cur.execute("SELECT 'Hello World!' FROM dual")

--- a/tests/docker/test_postgres.py
+++ b/tests/docker/test_postgres.py
@@ -112,7 +112,7 @@ async def test_postgres_16_config(
 
 
 async def test_postgres_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres_service: DockerServiceRegistry,
     postgres_port: int,
     postgres_database: str,
@@ -120,7 +120,7 @@ async def test_postgres_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres_port,
         database=postgres_database,
         user=postgres_user,
@@ -130,7 +130,7 @@ async def test_postgres_services(
 
 
 async def test_postgres_12_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres12_service: DockerServiceRegistry,
     postgres12_port: int,
     postgres_database: str,
@@ -138,7 +138,7 @@ async def test_postgres_12_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres12_port,
         database=postgres_database,
         user=postgres_user,
@@ -148,7 +148,7 @@ async def test_postgres_12_services(
 
 
 async def test_postgres_13_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres13_service: DockerServiceRegistry,
     postgres13_port: int,
     postgres_database: str,
@@ -156,7 +156,7 @@ async def test_postgres_13_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres13_port,
         database=postgres_database,
         user=postgres_user,
@@ -166,7 +166,7 @@ async def test_postgres_13_services(
 
 
 async def test_postgres_14_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres14_service: DockerServiceRegistry,
     postgres14_port: int,
     postgres_database: str,
@@ -174,7 +174,7 @@ async def test_postgres_14_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres14_port,
         database=postgres_database,
         user=postgres_user,
@@ -184,7 +184,7 @@ async def test_postgres_14_services(
 
 
 async def test_postgres_15_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres15_service: DockerServiceRegistry,
     postgres15_port: int,
     postgres_database: str,
@@ -192,7 +192,7 @@ async def test_postgres_15_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres15_port,
         database=postgres_database,
         user=postgres_user,
@@ -202,7 +202,7 @@ async def test_postgres_15_services(
 
 
 async def test_postgres_16_services(
-    docker_ip: str,
+    postgres_docker_ip: str,
     postgres16_service: DockerServiceRegistry,
     postgres16_port: int,
     postgres_database: str,
@@ -210,7 +210,7 @@ async def test_postgres_16_services(
     postgres_password: str,
 ) -> None:
     ping = await postgres_responsive(
-        docker_ip,
+        postgres_docker_ip,
         port=postgres16_port,
         database=postgres_database,
         user=postgres_user,

--- a/tests/docker/test_redis.py
+++ b/tests/docker/test_redis.py
@@ -43,9 +43,9 @@ def test_redis_default_config(redis_port: int) -> None:
 
 
 async def test_redis_service(
-    docker_ip: str,
+    redis_docker_ip: str,
     redis_service: DockerServiceRegistry,
     redis_port: int,
 ) -> None:
-    ping = await redis_responsive(docker_ip, redis_port)
+    ping = await redis_responsive(redis_docker_ip, redis_port)
     assert ping

--- a/tests/docker/test_spanner.py
+++ b/tests/docker/test_spanner.py
@@ -49,7 +49,7 @@ async def test_spanner_default_config(
 
 
 async def test_spanner_services(
-    docker_ip: str,
+    spanner_docker_ip: str,
     spanner_service: DockerServiceRegistry,
     spanner_port: int,
     spanner_instance: str,
@@ -58,7 +58,7 @@ async def test_spanner_services(
     spanner_credentials: Credentials,
 ) -> None:
     ping = spanner_responsive(
-        docker_ip,
+        spanner_docker_ip,
         spanner_port=spanner_port,
         spanner_instance=spanner_instance,
         spanner_database=spanner_database,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR allows each service to have it's own name, compose project files, and other service configurations.  Previously, this was shared globally.  Under certain cases, the fixture for the compose yaml file would be set incorrectly in user tests.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- 
