### PR TITLE
fix(valkey): Use the correct image name

### DIFF
--- a/src/pytest_databases/docker/docker-compose.valkey.yml
+++ b/src/pytest_databases/docker/docker-compose.valkey.yml
@@ -1,6 +1,6 @@
 services:
   valkey:
-    image: valkey/valkey
+    image: valkey/valkey:latest
     ports:
       - "${VALKEY_PORT:-6308}:6379"
 networks:


### PR DESCRIPTION
## Description

- Uses the correct valkey image name `valkey/valkey:latest` as seen in https://hub.docker.com/r/valkey/valkey/tags

## Closes
Problems you didn't even know you will have.