### PR TITLE
refactor: Remove async dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ keywords = [
   "cockroachdb",
   "redis",
   "elasticsearch",
+  "azure",
 ]
 # options under https://pypi.org/classifiers/
 classifiers = [
@@ -59,10 +60,10 @@ dragonfly = ["redis"]
 elasticsearch7 = ["elasticsearch7[async]"]
 elasticsearch8 = ["elasticsearch8[async]"]
 keydb = ["redis"]
-mssql = ["aioodbc"]
-mysql = ["asyncmy>=0.2.9"]
+mssql = ["pyodbc"]
+mysql = ["pymysql"]
 oracle = ["oracledb"]
-postgres = ["asyncpg>=0.29.0"]
+postgres = ["psycopg>=3"]
 redis = ["redis"]
 spanner = ["google-cloud-spanner"]
 sqlite = ["aiosqlite"]
@@ -105,7 +106,6 @@ extra-dependencies = [
   "types-six",
   "types-decorator",
   "types-pyyaml",
-  "asyncpg-stubs",
   "types-docutils",
   "types-redis",
   # docs
@@ -146,7 +146,6 @@ extra-dependencies = [
   "types-six",
   "types-decorator",
   "types-pyyaml",
-  "asyncpg-stubs",
   "types-docutils",
   "types-redis",
   # docs
@@ -215,7 +214,6 @@ extra-dependencies = [
   "types-six",
   "types-decorator",
   "types-pyyaml",
-  "asyncpg-stubs",
   "types-docutils",
   "types-redis",
   # docs
@@ -241,6 +239,7 @@ features = [
   "elasticsearch7",
   "elasticsearch8",
   "bigquery",
+  "azure-storage",
 ]
 python = "3.11"
 template = "default"
@@ -280,7 +279,6 @@ extra-dependencies = [
   "types-six",
   "types-decorator",
   "types-pyyaml",
-  "asyncpg-stubs",
   "types-docutils",
   "types-redis",
   # docs
@@ -305,6 +303,7 @@ features = [
   "elasticsearch7",
   "elasticsearch8",
   "bigquery",
+  "azure-storage",
 ]
 path = ".venv/"
 python = "3.11"
@@ -335,7 +334,6 @@ extra-dependencies = [
   "types-six",
   "types-decorator",
   "types-pyyaml",
-  "asyncpg-stubs",
   "types-docutils",
   "types-redis",
   # docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ azure-storage = ["azure-storage-blob"]
 bigquery = ["google-cloud-bigquery"]
 cockroachdb = ["psycopg"]
 dragonfly = ["redis"]
-elasticsearch7 = ["elasticsearch7[async]"]
-elasticsearch8 = ["elasticsearch8[async]"]
+elasticsearch7 = ["elasticsearch7"]
+elasticsearch8 = ["elasticsearch8"]
 keydb = ["redis"]
 mssql = ["pymssql"]
 mysql = ["pymysql"]
@@ -478,7 +478,6 @@ module = ["docutils.nodes.*"]
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "asyncmy",
   "pyodbc",
   "google.auth.*",
   "google.cloud.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ extra-dependencies = [
   "types-pyyaml",
   "types-docutils",
   "types-redis",
+  "types-pymysql",
   # docs
   "sphinx>=7.1.2",
   "sphinx-autobuild>=2021.3.14",
@@ -148,6 +149,7 @@ extra-dependencies = [
   "types-pyyaml",
   "types-docutils",
   "types-redis",
+  "types-pymysql",
   # docs
   "sphinx>=7.1.2",
   "sphinx-autobuild>=2021.3.14",
@@ -216,6 +218,7 @@ extra-dependencies = [
   "types-pyyaml",
   "types-docutils",
   "types-redis",
+  "types-pymysql",
   # docs
   "sphinx>=7.1.2",
   "sphinx-autobuild>=2021.3.14",
@@ -281,6 +284,7 @@ extra-dependencies = [
   "types-pyyaml",
   "types-docutils",
   "types-redis",
+  "types-pymysql",
   # docs
   "sphinx>=7.1.2",
   "sphinx-autobuild>=2021.3.14",
@@ -336,6 +340,7 @@ extra-dependencies = [
   "types-pyyaml",
   "types-docutils",
   "types-redis",
+  "types-pymysql",
   # docs
   "sphinx>=7.1.2",
   "sphinx-autobuild>=2021.3.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ allow-direct-references = true
 [tool.hatch.envs.default]
 extra-dependencies = [
   # tests
-  "anyio",
   "coverage[toml]>=6.2",
   "coverage[toml]>=6.2",
   "pytest",
@@ -127,7 +126,6 @@ python = "3.12"
 [tool.hatch.envs.test]
 extra-dependencies = [
   # tests
-  "anyio",
   "coverage[toml]>=6.2",
   "coverage[toml]>=6.2",
   "pytest",
@@ -195,7 +193,6 @@ no-cov = "cov --no-cov"
 [tool.hatch.envs.docs]
 extra-dependencies = [
   # tests
-  "anyio",
   "coverage[toml]>=6.2",
   "coverage[toml]>=6.2",
   "pytest",
@@ -260,7 +257,6 @@ build-check = ["build", "validate"]
 [tool.hatch.envs.local]
 extra-dependencies = [
   # tests
-  "anyio",
   "coverage[toml]>=6.2",
   "coverage[toml]>=6.2",
   "pytest",
@@ -315,7 +311,6 @@ type = "virtual"
 [tool.hatch.envs.lint]
 extra-dependencies = [
   # tests
-  "anyio",
   "coverage[toml]>=6.2",
   "coverage[toml]>=6.2",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ oracle = ["oracledb"]
 postgres = ["psycopg>=3"]
 redis = ["redis"]
 spanner = ["google-cloud-spanner"]
-sqlite = ["aiosqlite"]
 
 
 ######################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dragonfly = ["redis"]
 elasticsearch7 = ["elasticsearch7[async]"]
 elasticsearch8 = ["elasticsearch8[async]"]
 keydb = ["redis"]
-mssql = ["pyodbc"]
+mssql = ["pymssql"]
 mysql = ["pymysql"]
 oracle = ["oracledb"]
 postgres = ["psycopg>=3"]
@@ -94,7 +94,6 @@ extra-dependencies = [
   "pytest-cov",
   "pytest-mock",
   "pytest-vcr",
-  "pytest-sugar",
   "pytest-click",
   "pytest-xdist",
   # lint
@@ -135,7 +134,6 @@ extra-dependencies = [
   "pytest-cov",
   "pytest-mock",
   "pytest-vcr",
-  "pytest-sugar",
   "pytest-click",
   "pytest-xdist",
   # lint
@@ -204,7 +202,6 @@ extra-dependencies = [
   "pytest-cov",
   "pytest-mock",
   "pytest-vcr",
-  "pytest-sugar",
   "pytest-click",
   "pytest-xdist",
   # lint
@@ -270,7 +267,6 @@ extra-dependencies = [
   "pytest-cov",
   "pytest-mock",
   "pytest-vcr",
-  "pytest-sugar",
   "pytest-click",
   "pytest-xdist",
   # lint
@@ -326,7 +322,6 @@ extra-dependencies = [
   "pytest-cov",
   "pytest-mock",
   "pytest-vcr",
-  "pytest-sugar",
   "pytest-click",
   "pytest-xdist",
   # lint

--- a/src/pytest_databases/docker/__init__.py
+++ b/src/pytest_databases/docker/__init__.py
@@ -17,33 +17,7 @@ if TYPE_CHECKING:
 TRUE_VALUES = {"True", "true", "1", "yes", "Y", "T"}
 
 
-async def _wait_until_responsive(
-    check: Callable[..., Awaitable],
-    timeout: float,  # noqa: ASYNC109
-    pause: float,
-    **kwargs: Any,
-) -> None:
-    """Wait until a service is responsive.
-
-    Args:
-        check: Coroutine, return truthy value when waiting should stop.
-        timeout: Maximum seconds to wait.
-        pause: Seconds to wait between calls to `check`.
-        **kwargs: Given as kwargs to `check`.
-    """
-    ref = timeit.default_timer()
-    now = ref
-    while (now - ref) < timeout:  # sourcery skip
-        if await check(**kwargs):
-            return
-        await asyncio.sleep(pause)
-        now = timeit.default_timer()
-
-    msg = "Timeout reached while waiting on service!"
-    raise RuntimeError(msg)
-
-
-def wait_until_responsive_sync(
+def wait_until_responsive(
     check: Callable[..., bool],
     timeout: float,
     pause: float,
@@ -128,7 +102,7 @@ class DockerServiceRegistry:
             self.run_command("up", "--force-recreate", "-d", name)
             self._running_services.add(name)
 
-        wait_until_responsive_sync(
+        wait_until_responsive(
             check=check,
             timeout=timeout,
             pause=pause,

--- a/src/pytest_databases/docker/__init__.py
+++ b/src/pytest_databases/docker/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import os
 import re
 import subprocess  # noqa: S404
@@ -8,7 +7,7 @@ import time
 import timeit
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
-from pytest_databases.helpers import simple_string_hash, wrap_sync
+from pytest_databases.helpers import simple_string_hash
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Generator

--- a/src/pytest_databases/docker/alloydb_omni.py
+++ b/src/pytest_databases/docker/alloydb_omni.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import psycopg
 import pytest
@@ -101,7 +101,7 @@ def alloydb_omni_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -128,7 +128,7 @@ def alloydb_omni_startup_connection(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[psycopg.Connection, None]:
+) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(
         host=alloydb_docker_ip,
         port=alloydb_omni_port,

--- a/src/pytest_databases/docker/azure_blob.py
+++ b/src/pytest_databases/docker/azure_blob.py
@@ -140,7 +140,7 @@ async def azure_blob_async_container_client(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def azure_blob_service(
+def azure_blob_service(
     azure_blob_docker_services: DockerServiceRegistry,
     default_azure_blob_redis_service_name: str,
     azure_blob_docker_compose_files: list[Path],
@@ -157,7 +157,7 @@ async def azure_blob_service(
         logs = _get_container_logs(str(azure_blob_docker_compose_files[0].absolute()))
         return "Azurite Blob service successfully listens on" in logs
 
-    await azure_blob_docker_services.start(
+    azure_blob_docker_services.start(
         name=default_azure_blob_redis_service_name,
         docker_compose_files=azure_blob_docker_compose_files,
         check=azurite_responsive,

--- a/src/pytest_databases/docker/azure_blob.py
+++ b/src/pytest_databases/docker/azure_blob.py
@@ -147,7 +147,7 @@ def azure_blob_service(
     azure_blob_connection_string: str,
     azure_blob_port: int,
     azure_blob_default_container_name: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["AZURE_BLOB_PORT"] = str(azure_blob_port)
 
     def azurite_responsive(host: str, port: int) -> bool:

--- a/src/pytest_databases/docker/bigquery.py
+++ b/src/pytest_databases/docker/bigquery.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-bigquery-{simple_string_hash(__file__)}"
 
 
-async def bigquery_responsive(
+def bigquery_responsive(
     host: str,
     bigquery_endpoint: str,
     bigquery_dataset: str,
@@ -111,7 +111,7 @@ def bigquery_endpoint(bigquery_docker_ip: str, bigquery_port: int) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def bigquery_service(
+def bigquery_service(
     bigquery_docker_services: DockerServiceRegistry,
     default_bigquery_service_name: str,
     bigquery_docker_compose_files: list[Path],
@@ -128,7 +128,7 @@ async def bigquery_service(
     os.environ["BIGQUERY_PORT"] = str(bigquery_port)
     os.environ["BIGQUERY_GRPC_PORT"] = str(bigquery_grpc_port)
     os.environ["GOOGLE_CLOUD_PROJECT"] = bigquery_project
-    await bigquery_docker_services.start(
+    bigquery_docker_services.start(
         name=default_bigquery_service_name,
         docker_compose_files=bigquery_docker_compose_files,
         timeout=60,
@@ -143,12 +143,12 @@ async def bigquery_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def bigquery_startup_connection(
+def bigquery_startup_connection(
     bigquery_service: DockerServiceRegistry,
     bigquery_project: str,
     bigquery_credentials: Credentials,
     bigquery_client_options: ClientOptions,
-) -> AsyncGenerator[bigquery.Client, None]:
+) -> Generator[bigquery.Client, None, None]:
     yield bigquery.Client(
         project=bigquery_project, client_options=bigquery_client_options, credentials=bigquery_credentials
     )

--- a/src/pytest_databases/docker/bigquery.py
+++ b/src/pytest_databases/docker/bigquery.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
 from google.api_core.client_options import ClientOptions
@@ -122,7 +122,7 @@ def bigquery_service(
     bigquery_project: str,
     bigquery_credentials: Credentials,
     bigquery_client_options: ClientOptions,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["BIGQUERY_ENDPOINT"] = bigquery_endpoint
     os.environ["BIGQUERY_DATASET"] = bigquery_dataset
     os.environ["BIGQUERY_PORT"] = str(bigquery_port)

--- a/src/pytest_databases/docker/cockroachdb.py
+++ b/src/pytest_databases/docker/cockroachdb.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import psycopg
 import pytest
@@ -89,7 +89,7 @@ def cockroachdb_service(
     cockroachdb_port: int,
     cockroachdb_database: str,
     cockroachdb_driver_opts: dict[str, str],
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["COCKROACHDB_DATABASE"] = cockroachdb_database
     os.environ["COCKROACHDB_PORT"] = str(cockroachdb_port)
     cockroachdb_docker_services.start(

--- a/src/pytest_databases/docker/cockroachdb.py
+++ b/src/pytest_databases/docker/cockroachdb.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
-import asyncpg
+import psycopg
 import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
@@ -18,18 +18,18 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-cockroachdb-{simple_string_hash(__file__)}"
 
 
-async def cockroachdb_responsive(host: str, port: int, database: str, driver_opts: dict[str, str]) -> bool:
+def cockroachdb_responsive(host: str, port: int, database: str, driver_opts: dict[str, str]) -> bool:
     opts = "&".join(f"{k}={v}" for k, v in driver_opts.items()) if driver_opts else ""
     try:
-        conn = await asyncpg.connect(f"postgresql://root@{host}:{port}/{database}?{opts}")
+        conn = psycopg.connect(f"postgresql://root@{host}:{port}/{database}?{opts}")
     except Exception:  # noqa: BLE001
         return False
 
     try:
-        db_open = await conn.fetchrow("SELECT 1")
+        db_open = conn.execute("SELECT 1").fetchone()
         return bool(db_open is not None and db_open[0] == 1)
     finally:
-        await conn.close()
+        conn.close()
 
 
 @pytest.fixture(scope="session")
@@ -82,7 +82,7 @@ def cockroachdb_docker_ip(cockroachdb_docker_services: DockerServiceRegistry) ->
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def cockroachdb_service(
+def cockroachdb_service(
     cockroachdb_docker_services: DockerServiceRegistry,
     default_cockroachdb_service_name: str,
     cockroachdb_docker_compose_files: list[Path],
@@ -92,7 +92,7 @@ async def cockroachdb_service(
 ) -> AsyncGenerator[None, None]:
     os.environ["COCKROACHDB_DATABASE"] = cockroachdb_database
     os.environ["COCKROACHDB_PORT"] = str(cockroachdb_port)
-    await cockroachdb_docker_services.start(
+    cockroachdb_docker_services.start(
         name=default_cockroachdb_service_name,
         docker_compose_files=cockroachdb_docker_compose_files,
         timeout=60,
@@ -106,18 +106,15 @@ async def cockroachdb_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def cockroachdb_startup_connection(
+def cockroachdb_startup_connection(
     cockroachdb_service: DockerServiceRegistry,
     cockroachdb_docker_ip: str,
     cockroachdb_port: int,
     cockroachdb_database: str,
     cockroachdb_driver_opts: dict[str, str],
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
+) -> Generator[psycopg.Connection, None, None]:
     opts = "&".join(f"{k}={v}" for k, v in cockroachdb_driver_opts.items()) if cockroachdb_driver_opts else ""
-    conn = await asyncpg.connect(
+    with psycopg.connect(
         f"postgresql://root@{cockroachdb_docker_ip}:{cockroachdb_port}/{cockroachdb_database}?{opts}"
-    )
-    try:
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()

--- a/src/pytest_databases/docker/dragonfly.py
+++ b/src/pytest_databases/docker/dragonfly.py
@@ -3,23 +3,18 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
-from redis import Redis
-from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pytest_databases.docker import DockerServiceRegistry
-from pytest_databases.helpers import simple_string_hash
 from pytest_databases.docker.redis import redis_responsive
+from pytest_databases.helpers import simple_string_hash
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-dragonfly-{simple_string_hash(__file__)}"
-
-
-
 
 
 @pytest.fixture(scope="session")

--- a/src/pytest_databases/docker/dragonfly.py
+++ b/src/pytest_databases/docker/dragonfly.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
-from redis.asyncio import Redis as AsyncRedis
+from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
+from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -18,14 +19,7 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-dragonfly-{simple_string_hash(__file__)}"
 
 
-async def dragonfly_responsive(host: str, port: int) -> bool:
-    client: AsyncRedis = AsyncRedis(host=host, port=port)
-    try:
-        return await client.ping()
-    except (ConnectionError, RedisConnectionError):
-        return False
-    finally:
-        await client.aclose()  # type: ignore[attr-defined]
+
 
 
 @pytest.fixture(scope="session")
@@ -68,17 +62,17 @@ def dragonfly_docker_ip(dragonfly_docker_services: DockerServiceRegistry) -> str
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def dragonfly_service(
+def dragonfly_service(
     dragonfly_docker_services: DockerServiceRegistry,
     default_dragonfly_service_name: str,
     dragonfly_docker_compose_files: list[Path],
     dragonfly_port: int,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["DRAGONFLY_PORT"] = str(dragonfly_port)
-    await dragonfly_docker_services.start(
+    dragonfly_docker_services.start(
         name=default_dragonfly_service_name,
         docker_compose_files=dragonfly_docker_compose_files,
-        check=dragonfly_responsive,
+        check=redis_responsive,
         port=dragonfly_port,
     )
     yield

--- a/src/pytest_databases/docker/elastic_search.py
+++ b/src/pytest_databases/docker/elastic_search.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from elasticsearch7 import AsyncElasticsearch as Elasticsearch8
 from elasticsearch7 import Elasticsearch as Elasticsearch7
+from elasticsearch7 import Elasticsearch as Elasticsearch8
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash

--- a/src/pytest_databases/docker/elastic_search.py
+++ b/src/pytest_databases/docker/elastic_search.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
-from elasticsearch7 import AsyncElasticsearch as Elasticsearch7
+from elasticsearch7 import Elasticsearch as Elasticsearch7
 from elasticsearch7 import AsyncElasticsearch as Elasticsearch8
 
 from pytest_databases.docker import DockerServiceRegistry
@@ -19,22 +19,22 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-elasticsearch-{simple_string_hash(__file__)}"
 
 
-async def elasticsearch7_responsive(scheme: str, host: str, port: int, user: str, password: str, database: str) -> bool:
+def elasticsearch7_responsive(scheme: str, host: str, port: int, user: str, password: str, database: str) -> bool:
     try:
-        async with Elasticsearch7(
+        with Elasticsearch7(
             hosts=[{"host": host, "port": port, "scheme": scheme}], verify_certs=False, http_auth=(user, password)
         ) as client:
-            return await client.ping()
+            return client.ping()
     except Exception:  # noqa: BLE001
         return False
 
 
-async def elasticsearch8_responsive(scheme: str, host: str, port: int, user: str, password: str, database: str) -> bool:
+def elasticsearch8_responsive(scheme: str, host: str, port: int, user: str, password: str, database: str) -> bool:
     try:
-        async with Elasticsearch8(
+        with Elasticsearch8(
             hosts=[{"host": host, "port": port, "scheme": scheme}], verify_certs=False, basic_auth=(user, password)
         ) as client:
-            return await client.ping()
+            return client.ping()
     except Exception:  # noqa: BLE001
         return False
 
@@ -104,7 +104,7 @@ def elasticsearch_docker_ip(elasticsearch_docker_services: DockerServiceRegistry
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def elasticsearch7_service(
+def elasticsearch7_service(
     elasticsearch_docker_services: DockerServiceRegistry,
     elasticsearch_docker_compose_files: list[Path],
     elasticsearch7_port: int,
@@ -112,8 +112,8 @@ async def elasticsearch7_service(
     elasticsearch_user: str,
     elasticsearch_password: str,
     elasticsearch_scheme: str,
-) -> AsyncGenerator[None, None]:
-    await elasticsearch_docker_services.start(
+) -> Generator[None, None, None]:
+    elasticsearch_docker_services.start(
         "elasticsearch7",
         docker_compose_files=elasticsearch_docker_compose_files,
         timeout=45,
@@ -129,7 +129,7 @@ async def elasticsearch7_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def elasticsearch8_service(
+def elasticsearch8_service(
     elasticsearch_docker_services: DockerServiceRegistry,
     elasticsearch_docker_compose_files: list[Path],
     elasticsearch8_port: int,
@@ -137,8 +137,8 @@ async def elasticsearch8_service(
     elasticsearch_user: str,
     elasticsearch_password: str,
     elasticsearch_scheme: str,
-) -> AsyncGenerator[None, None]:
-    await elasticsearch_docker_services.start(
+) -> Generator[None, None, None]:
+    elasticsearch_docker_services.start(
         "elasticsearch8",
         docker_compose_files=elasticsearch_docker_compose_files,
         timeout=45,
@@ -154,7 +154,7 @@ async def elasticsearch8_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def elasticsearch_service(
+def elasticsearch_service(
     elasticsearch_docker_services: DockerServiceRegistry,
     default_elasticsearch_service_name: str,
     elasticsearch_docker_compose_files: list[Path],
@@ -163,8 +163,8 @@ async def elasticsearch_service(
     elasticsearch_user: str,
     elasticsearch_password: str,
     elasticsearch_scheme: str,
-) -> AsyncGenerator[None, None]:
-    await elasticsearch_docker_services.start(
+) -> Generator[None, None, None]:
+    elasticsearch_docker_services.start(
         name=default_elasticsearch_service_name,
         docker_compose_files=elasticsearch_docker_compose_files,
         timeout=45,

--- a/src/pytest_databases/docker/elastic_search.py
+++ b/src/pytest_databases/docker/elastic_search.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
-from elasticsearch7 import Elasticsearch as Elasticsearch7
 from elasticsearch7 import AsyncElasticsearch as Elasticsearch8
+from elasticsearch7 import Elasticsearch as Elasticsearch7
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash

--- a/src/pytest_databases/docker/keydb.py
+++ b/src/pytest_databases/docker/keydb.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
-from redis import Redis
-from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pytest_databases.docker import DockerServiceRegistry
-from pytest_databases.helpers import simple_string_hash
 from pytest_databases.docker.redis import redis_responsive
+from pytest_databases.helpers import simple_string_hash
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/src/pytest_databases/docker/keydb.py
+++ b/src/pytest_databases/docker/keydb.py
@@ -6,27 +6,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
-from redis.asyncio import Redis as AsyncRedis
+from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
+from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-keydb-{simple_string_hash(__file__)}"
-
-
-async def keydb_responsive(host: str, port: int) -> bool:
-    client: AsyncRedis = AsyncRedis(host=host, port=port)
-    try:
-        return await client.ping()
-    except (ConnectionError, RedisConnectionError):
-        return False
-    finally:
-        await client.aclose()  # type: ignore[attr-defined]
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -69,17 +60,17 @@ def keydb_docker_ip(keydb_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def keydb_service(
+def keydb_service(
     keydb_docker_services: DockerServiceRegistry,
     default_keydb_service_name: str,
     keydb_docker_compose_files: list[Path],
     keydb_port: int,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["KEYDB_PORT"] = str(keydb_port)
-    await keydb_docker_services.start(
+    keydb_docker_services.start(
         name=default_keydb_service_name,
         docker_compose_files=keydb_docker_compose_files,
-        check=keydb_responsive,
+        check=redis_responsive,
         port=keydb_port,
     )
     yield

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -1,25 +1,22 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, Generator
 
+import pymysql
 import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.docker.mysql import mysql_responsive
 from pytest_databases.helpers import simple_string_hash
-import pymysql
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-mariadb-{simple_string_hash(__file__)}"
-
-
 
 
 @pytest.fixture(scope="session")
@@ -146,38 +143,38 @@ def mariadb_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mariadb_startup_connection(
+def mariadb_startup_connection(
     mariadb_service: DockerServiceRegistry,
     mariadb_docker_ip: str,
     mariadb_port: int,
     mariadb_database: str,
     mariadb_user: str,
     mariadb_password: str,
-) -> AsyncGenerator[Any, None]:
-    conn = await asyncmy.connect(
+) -> Generator[Any, None, None]:
+    with pymysql.connect(
         host=mariadb_docker_ip,
         port=mariadb_port,
         user=mariadb_user,
         database=mariadb_database,
         password=mariadb_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mariadb113_startup_connection(
+def mariadb113_startup_connection(
     mariadb113_service: DockerServiceRegistry,
     mariadb_docker_ip: str,
     mariadb113_port: int,
     mariadb_database: str,
     mariadb_user: str,
     mariadb_password: str,
-) -> AsyncGenerator[Any, None]:
-    conn = await asyncmy.connect(
+) -> Generator[Any, None, None]:
+    with pymysql.connect(
         host=mariadb_docker_ip,
         port=mariadb113_port,
         user=mariadb_user,
         database=mariadb_database,
         password=mariadb_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -6,11 +6,12 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
-import asyncmy
 import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.docker.mysql import mysql_responsive
 from pytest_databases.helpers import simple_string_hash
+import pymysql
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -19,26 +20,6 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-mariadb-{simple_string_hash(__file__)}"
 
 
-async def mariadb_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
-    try:
-        conn = await asyncmy.connect(
-            host=host,
-            port=port,
-            user=user,
-            database=database,
-            password=password,
-        )
-    except Exception:  # noqa: BLE001
-        return False
-
-    try:
-        async with conn.cursor() as cursor:
-            await cursor.execute("select 1 as is_available")
-            resp = await cursor.fetchone()
-        return resp[0] == 1
-    finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
 
 
 @pytest.fixture(scope="session")
@@ -106,7 +87,7 @@ def mariadb_docker_ip(mariadb_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mariadb113_service(
+def mariadb113_service(
     mariadb_docker_services: DockerServiceRegistry,
     mariadb_docker_compose_files: list[Path],
     mariadb113_port: int,
@@ -114,18 +95,18 @@ async def mariadb113_service(
     mariadb_user: str,
     mariadb_password: str,
     mariadb_root_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["MARIADB_ROOT_PASSWORD"] = mariadb_root_password
     os.environ["MARIADB_PASSWORD"] = mariadb_password
     os.environ["MARIADB_USER"] = mariadb_user
     os.environ["MARIADB_DATABASE"] = mariadb_database
     os.environ["MARIADB113_PORT"] = str(mariadb113_port)
-    await mariadb_docker_services.start(
+    mariadb_docker_services.start(
         "mariadb113",
         docker_compose_files=mariadb_docker_compose_files,
         timeout=45,
         pause=1,
-        check=mariadb_responsive,
+        check=mysql_responsive,
         port=mariadb113_port,
         database=mariadb_database,
         user=mariadb_user,
@@ -135,7 +116,7 @@ async def mariadb113_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mariadb_service(
+def mariadb_service(
     mariadb_docker_services: DockerServiceRegistry,
     default_mariadb_service_name: str,
     mariadb_docker_compose_files: list[Path],
@@ -144,18 +125,18 @@ async def mariadb_service(
     mariadb_user: str,
     mariadb_password: str,
     mariadb_root_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["MARIADB_ROOT_PASSWORD"] = mariadb_root_password
     os.environ["MARIADB_PASSWORD"] = mariadb_password
     os.environ["MARIADB_USER"] = mariadb_user
     os.environ["MARIADB_DATABASE"] = mariadb_database
     os.environ[f"{default_mariadb_service_name.upper()}_PORT"] = str(mariadb_port)
-    await mariadb_docker_services.start(
+    mariadb_docker_services.start(
         name=default_mariadb_service_name,
         docker_compose_files=mariadb_docker_compose_files,
         timeout=45,
         pause=1,
-        check=mariadb_responsive,
+        check=mysql_responsive,
         port=mariadb_port,
         database=mariadb_database,
         user=mariadb_user,

--- a/src/pytest_databases/docker/mssql.py
+++ b/src/pytest_databases/docker/mssql.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pyodbc
 import pytest
@@ -20,7 +19,6 @@ COMPOSE_PROJECT_NAME: str = f"pytest-databases-mssql-{simple_string_hash(__file_
 
 
 def mssql_responsive(host: str, connstring: str) -> bool:
-    asyncio.sleep(1)
     try:
         conn = pyodbc.connect(
             dsn=connstring,

--- a/src/pytest_databases/docker/mssql.py
+++ b/src/pytest_databases/docker/mssql.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
-import aioodbc
+import pyodbc
 import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
@@ -19,16 +19,16 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-mssql-{simple_string_hash(__file__)}"
 
 
-async def mssql_responsive(host: str, connstring: str) -> bool:
-    await asyncio.sleep(1)
+def mssql_responsive(host: str, connstring: str) -> bool:
+    asyncio.sleep(1)
     try:
-        conn = await aioodbc.connect(
+        conn = pyodbc.connect(
             dsn=connstring,
             timeout=2,
         )
-        async with conn.cursor() as cursor:
-            await cursor.execute("select 1 as is_available")
-            resp = await cursor.fetchone()
+        with conn.cursor() as cursor:
+            cursor.execute("select 1 as is_available")
+            resp = cursor.fetchone()
             return resp[0] == 1 if resp is not None else False
     except Exception:  # noqa: BLE001
         return False
@@ -108,7 +108,7 @@ def mssql2022_connection_string(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mssql2022_service(
+def mssql2022_service(
     mssql_docker_services: DockerServiceRegistry,
     mssql_docker_compose_files: list[Path],
     mssql_docker_ip: str,
@@ -117,12 +117,12 @@ async def mssql2022_service(
     mssql_user: str,
     mssql_password: str,
     mssql2022_connection_string: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["MSSQL_PASSWORD"] = mssql_password
     os.environ["MSSQL_USER"] = mssql_user
     os.environ["MSSQL_DATABASE"] = mssql_database
     os.environ["MSSQL2022_PORT"] = str(mssql2022_port)
-    await mssql_docker_services.start(
+    mssql_docker_services.start(
         "mssql2022",
         docker_compose_files=mssql_docker_compose_files,
         timeout=120,
@@ -134,7 +134,7 @@ async def mssql2022_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mssql_service(
+def mssql_service(
     mssql_docker_services: DockerServiceRegistry,
     default_mssql_service_name: str,
     mssql_docker_compose_files: list[Path],
@@ -144,12 +144,12 @@ async def mssql_service(
     mssql_user: str,
     mssql_password: str,
     mssql_connection_string: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["MSSQL_PASSWORD"] = mssql_password
     os.environ["MSSQL_USER"] = mssql_user
     os.environ["MSSQL_DATABASE"] = mssql_database
     os.environ[f"{default_mssql_service_name.upper()}_PORT"] = str(mssql_port)
-    await mssql_docker_services.start(
+    mssql_docker_services.start(
         name=default_mssql_service_name,
         docker_compose_files=mssql_docker_compose_files,
         timeout=120,
@@ -161,10 +161,10 @@ async def mssql_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mssql_startup_connection(
+def mssql_startup_connection(
     mssql_service: DockerServiceRegistry, mssql_connection_string: str
-) -> AsyncGenerator[aioodbc.Connection, None]:
-    async with await aioodbc.connect(
+) -> Generator[pyodbc.Connection, None, None]:
+    with pyodbc.connect(
         dsn=mssql_connection_string,
         timeout=2,
     ) as db_connection:
@@ -172,10 +172,10 @@ async def mssql_startup_connection(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mssql2022_startup_connection(
+def mssql2022_startup_connection(
     mssql2022_service: DockerServiceRegistry, mssql2022_connection_string: str
-) -> AsyncGenerator[aioodbc.Connection, None]:
-    async with await aioodbc.connect(
+) -> Generator[pyodbc.Connection, None, None]:
+    with pyodbc.connect(
         dsn=mssql2022_connection_string,
         timeout=2,
     ) as db_connection:

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -4,13 +4,13 @@ import contextlib
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any
 
+import pymysql
 import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
-import pymysql
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -35,7 +35,7 @@ def mysql_responsive(host: str, port: int, user: str, password: str, database: s
         with conn.cursor() as cursor:
             cursor.execute("select 1 as is_available")
             resp = cursor.fetchone()
-        return resp[0] == 1
+        return resp is not None and resp[0] == 1
     finally:
         with contextlib.suppress(Exception):
             conn.close()
@@ -241,14 +241,14 @@ def mysql_startup_connection(
     mysql_user: str,
     mysql_password: str,
 ) -> Generator[Any, None, None]:
-    conn = pymysql.connect(
+    with pymysql.connect(
         host=mysql_docker_ip,
         port=mysql_port,
         user=mysql_user,
         database=mysql_database,
         password=mysql_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -260,18 +260,18 @@ def mysql56_startup_connection(
     mysql_user: str,
     mysql_password: str,
 ) -> Generator[Any, None, None]:
-    conn = pymysql.connect(
+    with pymysql.connect(
         host=mysql_docker_ip,
         port=mysql56_port,
         user=mysql_user,
         database=mysql_database,
         password=mysql_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def mysql57_startup_connection(
+def mysql57_startup_connection(
     mysql57_service: DockerServiceRegistry,
     mysql_docker_ip: str,
     mysql57_port: int,
@@ -279,14 +279,14 @@ async def mysql57_startup_connection(
     mysql_user: str,
     mysql_password: str,
 ) -> Generator[Any, None, None]:
-    conn = pymysql.connect(
+    with pymysql.connect(
         host=mysql_docker_ip,
         port=mysql57_port,
         user=mysql_user,
         database=mysql_database,
         password=mysql_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -298,11 +298,11 @@ def mysql8_startup_connection(
     mysql_user: str,
     mysql_password: str,
 ) -> Generator[Any, None, None]:
-    conn = pymysql.connect(
+    with pymysql.connect(
         host=mysql_docker_ip,
         port=mysql8_port,
         user=mysql_user,
         database=mysql_database,
         password=mysql_password,
-    )
-    yield conn
+    ) as conn:
+        yield conn

--- a/src/pytest_databases/docker/oracle.py
+++ b/src/pytest_databases/docker/oracle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import oracledb
 import pytest
@@ -223,7 +223,7 @@ def oracle_startup_connection(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def oracle18c_startup_connection(
+def oracle18c_startup_connection(
     oracle18c_service: DockerServiceRegistry,
     oracle_docker_ip: str,
     oracle18c_port: int,
@@ -242,7 +242,7 @@ async def oracle18c_startup_connection(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def oracle23ai_startup_connection(
+def oracle23ai_startup_connection(
     oracle23ai_service: DockerServiceRegistry,
     oracle_docker_ip: str,
     oracle23ai_port: int,

--- a/src/pytest_databases/docker/oracle.py
+++ b/src/pytest_databases/docker/oracle.py
@@ -115,7 +115,7 @@ def oracle_docker_ip(oracle_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def oracle23ai_service(
+def oracle23ai_service(
     oracle_docker_services: DockerServiceRegistry,
     oracle_docker_compose_files: list[Path],
     oracle23ai_port: int,
@@ -123,13 +123,13 @@ async def oracle23ai_service(
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE23AI_SERVICE_NAME"] = oracle23ai_service_name
     os.environ["ORACLE23AI_PORT"] = str(oracle23ai_port)
-    await oracle_docker_services.start(
+    oracle_docker_services.start(
         "oracle23ai",
         docker_compose_files=oracle_docker_compose_files,
         timeout=90,
@@ -144,7 +144,7 @@ async def oracle23ai_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def oracle18c_service(
+def oracle18c_service(
     oracle_docker_services: DockerServiceRegistry,
     oracle_docker_compose_files: list[Path],
     oracle18c_port: int,
@@ -152,13 +152,13 @@ async def oracle18c_service(
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE18C_SERVICE_NAME"] = oracle18c_service_name
     os.environ["ORACLE18C_PORT"] = str(oracle18c_port)
-    await oracle_docker_services.start(
+    oracle_docker_services.start(
         "oracle18c",
         docker_compose_files=oracle_docker_compose_files,
         timeout=90,
@@ -174,7 +174,7 @@ async def oracle18c_service(
 
 # alias to the latest
 @pytest.fixture(autouse=False, scope="session")
-async def oracle_service(
+def oracle_service(
     oracle_docker_services: DockerServiceRegistry,
     default_oracle_service_name: str,
     oracle_docker_compose_files: list[Path],
@@ -183,13 +183,13 @@ async def oracle_service(
     oracle_system_password: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None]:
     os.environ["ORACLE_PASSWORD"] = oracle_password
     os.environ["ORACLE_SYSTEM_PASSWORD"] = oracle_system_password
     os.environ["ORACLE_USER"] = oracle_user
     os.environ["ORACLE_SERVICE_NAME"] = oracle_service_name
     os.environ[f"{default_oracle_service_name.upper()}_PORT"] = str(oracle_port)
-    await oracle_docker_services.start(
+    oracle_docker_services.start(
         name=default_oracle_service_name,
         docker_compose_files=oracle_docker_compose_files,
         timeout=90,
@@ -204,15 +204,15 @@ async def oracle_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def oracle_startup_connection(
+def oracle_startup_connection(
     oracle_service: DockerServiceRegistry,
     oracle_docker_ip: str,
     oracle_port: int,
     oracle_service_name: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[oracledb.AsyncConnection, None]:
-    async with oracledb.connect_async(
+) -> Generator[oracledb.Connection, None, None]:
+    with oracledb.connect(
         host=oracle_docker_ip,
         port=oracle_port,
         user=oracle_user,
@@ -230,8 +230,8 @@ async def oracle18c_startup_connection(
     oracle18c_service_name: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[oracledb.AsyncConnection, None]:
-    async with oracledb.connect_async(
+) -> Generator[oracledb.Connection, None, None]:
+    with oracledb.connect(
         host=oracle_docker_ip,
         port=oracle18c_port,
         user=oracle_user,
@@ -249,8 +249,8 @@ async def oracle23ai_startup_connection(
     oracle23ai_service_name: str,
     oracle_user: str,
     oracle_password: str,
-) -> AsyncGenerator[oracledb.AsyncConnection, None]:
-    async with oracledb.connect_async(
+) -> Generator[oracledb.Connection, None, None]:
+    with oracledb.connect(
         host=oracle_docker_ip,
         port=oracle23ai_port,
         user=oracle_user,

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
-import pytest
 import psycopg
+import pytest
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
@@ -27,7 +27,7 @@ def postgres_responsive(host: str, port: int, user: str, password: str, database
         conn = psycopg.connect(
             _make_connection_string(host=host, port=port, user=user, password=password, database=database)
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return False
     try:
         db_open = conn.execute("SELECT 1").fetchone()
@@ -265,7 +265,7 @@ def postgres_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[DockerServiceRegistry, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -292,7 +292,7 @@ def postgres_startup_connection(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[psycopg.Connection, None, None]:
+) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(
         _make_connection_string(
             host=postgres_docker_ip,
@@ -334,7 +334,7 @@ def postgres15_startup_connection(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[psycopg.Connection, None, None]:
+) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(
         _make_connection_string(
             host=postgres_docker_ip,
@@ -355,7 +355,7 @@ def postgres14_startup_connection(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[psycopg.Connection, None, None]:
+) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(
         _make_connection_string(
             host=postgres_docker_ip,
@@ -376,7 +376,7 @@ def postgres13_startup_connection(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[psycopg.Connection, None, None]:
+) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(
         _make_connection_string(
             host=postgres_docker_ip,

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -24,16 +24,13 @@ def _make_connection_string(host: str, port: int, user: str, password: str, data
 
 def postgres_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
     try:
-        conn = psycopg.connect(
+        with psycopg.connect(
             _make_connection_string(host=host, port=port, user=user, password=password, database=database)
-        )
+        ) as conn:
+            db_open = conn.execute("SELECT 1").fetchone()
+            return bool(db_open is not None and db_open[0] == 1)
     except Exception:  # noqa: BLE001
         return False
-    try:
-        db_open = conn.execute("SELECT 1").fetchone()
-        return bool(db_open is not None and db_open[0] == 1)
-    finally:
-        conn.close()
 
 
 @pytest.fixture(scope="session")
@@ -128,7 +125,7 @@ def postgres12_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> Generator[None, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -144,7 +141,7 @@ def postgres12_service(
         user=postgres_user,
         password=postgres_password,
     )
-    yield
+    yield postgres_docker_services
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -155,7 +152,7 @@ def postgres13_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> Generator[None, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -171,7 +168,7 @@ def postgres13_service(
         user=postgres_user,
         password=postgres_password,
     )
-    yield
+    yield postgres_docker_services
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -182,7 +179,7 @@ def postgres14_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> Generator[None, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -198,7 +195,7 @@ def postgres14_service(
         user=postgres_user,
         password=postgres_password,
     )
-    yield
+    yield postgres_docker_services
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -209,7 +206,7 @@ def postgres15_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> Generator[None, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -225,7 +222,7 @@ def postgres15_service(
         user=postgres_user,
         password=postgres_password,
     )
-    yield
+    yield postgres_docker_services
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -236,7 +233,7 @@ def postgres16_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> Generator[None, None, None]:
+) -> Generator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
@@ -252,7 +249,7 @@ def postgres16_service(
         user=postgres_user,
         password=postgres_password,
     )
-    yield
+    yield postgres_docker_services
 
 
 # alias to the latest

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -5,8 +5,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
-import asyncpg
 import pytest
+import psycopg
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
@@ -18,23 +18,22 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-postgres-{simple_string_hash(__file__)}"
 
 
-async def postgres_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
-    try:
-        conn = await asyncpg.connect(
-            host=host,
-            port=port,
-            user=user,
-            database=database,
-            password=password,
-        )
-    except Exception:  # noqa: BLE001
-        return False
+def _make_connection_string(host: str, port: int, user: str, password: str, database: str) -> str:
+    return f"dbname={database} user={user} host={host} port={port} password={password}"
 
+
+def postgres_responsive(host: str, port: int, user: str, password: str, database: str) -> bool:
     try:
-        db_open = await conn.fetchrow("SELECT 1")
+        conn = psycopg.connect(
+            _make_connection_string(host=host, port=port, user=user, password=password, database=database)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return False
+    try:
+        db_open = conn.execute("SELECT 1").fetchone()
         return bool(db_open is not None and db_open[0] == 1)
     finally:
-        await conn.close()
+        conn.close()
 
 
 @pytest.fixture(scope="session")
@@ -122,19 +121,19 @@ def postgres_docker_ip(postgres_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres12_service(
+def postgres12_service(
     postgres_docker_services: DockerServiceRegistry,
     postgres_docker_compose_files: list[Path],
     postgres12_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES12_PORT"] = str(postgres12_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         "postgres12",
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -149,19 +148,19 @@ async def postgres12_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres13_service(
+def postgres13_service(
     postgres_docker_services: DockerServiceRegistry,
     postgres_docker_compose_files: list[Path],
     postgres13_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES13_PORT"] = str(postgres13_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         "postgres13",
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -176,19 +175,19 @@ async def postgres13_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres14_service(
+def postgres14_service(
     postgres_docker_services: DockerServiceRegistry,
     postgres_docker_compose_files: list[Path],
     postgres14_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES14_PORT"] = str(postgres14_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         "postgres14",
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -203,19 +202,19 @@ async def postgres14_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres15_service(
+def postgres15_service(
     postgres_docker_services: DockerServiceRegistry,
     postgres_docker_compose_files: list[Path],
     postgres15_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES15_PORT"] = str(postgres15_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         "postgres15",
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -230,19 +229,19 @@ async def postgres15_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres16_service(
+def postgres16_service(
     postgres_docker_services: DockerServiceRegistry,
     postgres_docker_compose_files: list[Path],
     postgres16_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ["POSTGRES16_PORT"] = str(postgres16_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         "postgres16",
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -258,7 +257,7 @@ async def postgres16_service(
 
 # alias to the latest
 @pytest.fixture(autouse=False, scope="session")
-async def postgres_service(
+def postgres_service(
     postgres_docker_services: DockerServiceRegistry,
     default_postgres_service_name: str,
     postgres_docker_compose_files: list[Path],
@@ -266,12 +265,12 @@ async def postgres_service(
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[DockerServiceRegistry, None]:
+) -> AsyncGenerator[DockerServiceRegistry, None, None]:
     os.environ["POSTGRES_PASSWORD"] = postgres_password
     os.environ["POSTGRES_USER"] = postgres_user
     os.environ["POSTGRES_DATABASE"] = postgres_database
     os.environ[f"{default_postgres_service_name.upper()}_PORT"] = str(postgres_port)
-    await postgres_docker_services.start(
+    postgres_docker_services.start(
         name=default_postgres_service_name,
         docker_compose_files=postgres_docker_compose_files,
         timeout=45,
@@ -286,132 +285,126 @@ async def postgres_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres_startup_connection(
+def postgres_startup_connection(
     postgres_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> AsyncGenerator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres16_startup_connection(
+def postgres16_startup_connection(
     postgres16_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres16_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres16_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> Generator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres16_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres15_startup_connection(
+def postgres15_startup_connection(
     postgres15_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres15_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres15_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> AsyncGenerator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres15_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres14_startup_connection(
+def postgres14_startup_connection(
     postgres14_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres14_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres14_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> AsyncGenerator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres14_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres13_startup_connection(
+def postgres13_startup_connection(
     postgres13_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres13_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres13_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> AsyncGenerator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres13_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def postgres12_startup_connection(
+def postgres12_startup_connection(
     postgres12_service: DockerServiceRegistry,
     postgres_docker_ip: str,
     postgres12_port: int,
     postgres_database: str,
     postgres_user: str,
     postgres_password: str,
-) -> AsyncGenerator[asyncpg.Connection[asyncpg.Record], None]:
-    conn = await asyncpg.connect(
-        host=postgres_docker_ip,
-        port=postgres12_port,
-        user=postgres_user,
-        database=postgres_database,
-        password=postgres_password,
-    )
-    try:
+) -> Generator[psycopg.Connection, None, None]:
+    with psycopg.connect(
+        _make_connection_string(
+            host=postgres_docker_ip,
+            port=postgres12_port,
+            user=postgres_user,
+            password=postgres_password,
+            database=postgres_database,
+        ),
+    ) as conn:
         yield conn
-    finally:
-        await conn.close()

--- a/src/pytest_databases/docker/redis.py
+++ b/src/pytest_databases/docker/redis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
 from redis import Redis
@@ -26,7 +26,7 @@ def redis_responsive(host: str, port: int) -> bool:
     except (ConnectionError, RedisConnectionError):
         return False
     finally:
-        client.close()  # type: ignore[attr-defined]
+        client.close()
 
 
 @pytest.fixture(scope="session")
@@ -74,7 +74,7 @@ def redis_service(
     default_redis_service_name: str,
     redis_docker_compose_files: list[Path],
     redis_port: int,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["REDIS_PORT"] = str(redis_port)
     redis_docker_services.start(
         name=default_redis_service_name,

--- a/src/pytest_databases/docker/redis.py
+++ b/src/pytest_databases/docker/redis.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 import pytest
-from redis.asyncio import Redis as AsyncRedis
+from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from pytest_databases.docker import DockerServiceRegistry
@@ -19,14 +19,14 @@ if TYPE_CHECKING:
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-redis-{simple_string_hash(__file__)}"
 
 
-async def redis_responsive(host: str, port: int) -> bool:
-    client: AsyncRedis = AsyncRedis(host=host, port=port)
+def redis_responsive(host: str, port: int) -> bool:
+    client = Redis(host=host, port=port)
     try:
-        return await client.ping()
+        return client.ping()
     except (ConnectionError, RedisConnectionError):
         return False
     finally:
-        await client.aclose()  # type: ignore[attr-defined]
+        client.close()  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="session")
@@ -69,14 +69,14 @@ def redis_docker_ip(redis_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def redis_service(
+def redis_service(
     redis_docker_services: DockerServiceRegistry,
     default_redis_service_name: str,
     redis_docker_compose_files: list[Path],
     redis_port: int,
 ) -> AsyncGenerator[None, None]:
     os.environ["REDIS_PORT"] = str(redis_port)
-    await redis_docker_services.start(
+    redis_docker_services.start(
         name=default_redis_service_name,
         docker_compose_files=redis_docker_compose_files,
         check=redis_responsive,

--- a/src/pytest_databases/docker/spanner.py
+++ b/src/pytest_databases/docker/spanner.py
@@ -105,7 +105,7 @@ def spanner_docker_ip(spanner_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def spanner_service(
+def spanner_service(
     spanner_docker_services: DockerServiceRegistry,
     default_spanner_service_name: str,
     spanner_docker_compose_files: list[Path],
@@ -121,7 +121,7 @@ async def spanner_service(
     os.environ["SPANNER_INSTANCE"] = spanner_instance
     os.environ["SPANNER_PORT"] = str(spanner_port)
     os.environ["GOOGLE_CLOUD_PROJECT"] = spanner_project
-    await spanner_docker_services.start(
+    spanner_docker_services.start(
         name=default_spanner_service_name,
         docker_compose_files=spanner_docker_compose_files,
         timeout=60,
@@ -136,10 +136,10 @@ async def spanner_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def spanner_startup_connection(
+def spanner_startup_connection(
     spanner_service: DockerServiceRegistry,
     spanner_project: str,
     spanner_credentials: Credentials,
-) -> AsyncGenerator[spanner.Client, None]:
+) -> Generator[spanner.Client, None, None]:
     c = spanner.Client(project=spanner_project, credentials=spanner_credentials)
     yield c

--- a/src/pytest_databases/docker/spanner.py
+++ b/src/pytest_databases/docker/spanner.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
 from google.auth.credentials import AnonymousCredentials, Credentials
@@ -115,7 +115,7 @@ def spanner_service(
     spanner_database: str,
     spanner_project: str,
     spanner_credentials: Credentials,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["SPANNER_EMULATOR_HOST"] = f"{spanner_docker_ip}:{spanner_port}"
     os.environ["SPANNER_DATABASE"] = spanner_database
     os.environ["SPANNER_INSTANCE"] = spanner_instance

--- a/src/pytest_databases/docker/valkey.py
+++ b/src/pytest_databases/docker/valkey.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, AsyncGenerator
 import pytest
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
+from pytest_databases.docker.redis import redis_responsive
+
 
 from pytest_databases.docker import DockerServiceRegistry
 from pytest_databases.helpers import simple_string_hash
@@ -17,16 +19,6 @@ if TYPE_CHECKING:
 
 
 COMPOSE_PROJECT_NAME: str = f"pytest-databases-valkey-{simple_string_hash(__file__)}"
-
-
-async def valkey_responsive(host: str, port: int) -> bool:
-    client: AsyncRedis = AsyncRedis(host=host, port=port)
-    try:
-        return await client.ping()
-    except (ConnectionError, RedisConnectionError):
-        return False
-    finally:
-        await client.aclose()  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="session")
@@ -69,17 +61,17 @@ def valkey_docker_ip(valkey_docker_services: DockerServiceRegistry) -> str:
 
 
 @pytest.fixture(autouse=False, scope="session")
-async def valkey_service(
+def valkey_service(
     valkey_docker_services: DockerServiceRegistry,
     default_valkey_service_name: str,
     valkey_docker_compose_files: list[Path],
     valkey_port: int,
-) -> AsyncGenerator[None, None]:
+) -> Generator[None, None, None]:
     os.environ["REDIS_PORT"] = str(valkey_port)
-    await valkey_docker_services.start(
+    valkey_docker_services.start(
         name=default_valkey_service_name,
         docker_compose_files=valkey_docker_compose_files,
-        check=valkey_responsive,
+        check=redis_responsive,
         port=valkey_port,
     )
     yield

--- a/src/pytest_databases/docker/valkey.py
+++ b/src/pytest_databases/docker/valkey.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
-from redis.asyncio import Redis as AsyncRedis
-from redis.exceptions import ConnectionError as RedisConnectionError
-from pytest_databases.docker.redis import redis_responsive
-
 
 from pytest_databases.docker import DockerServiceRegistry
+from pytest_databases.docker.redis import redis_responsive
 from pytest_databases.helpers import simple_string_hash
 
 if TYPE_CHECKING:

--- a/src/pytest_databases/helpers.py
+++ b/src/pytest_databases/helpers.py
@@ -1,64 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import inspect
-from contextlib import AbstractAsyncContextManager, AbstractContextManager
-from functools import partial
-from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
-
-import anyio
-from typing_extensions import ParamSpec
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
-    from types import TracebackType
-
-T = TypeVar("T")
-P = ParamSpec("P")
-
-
-class _ContextManagerWrapper:
-    def __init__(self, cm: AbstractContextManager[T]) -> None:
-        self._cm = cm
-
-    async def __aenter__(self) -> T:
-        return self._cm.__enter__()  # type: ignore[return-value]
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        return self._cm.__exit__(exc_type, exc_val, exc_tb)
-
-
-@overload
-async def maybe_async(obj: Awaitable[T]) -> T: ...
-
-
-@overload
-async def maybe_async(obj: T) -> T: ...
-
-
-async def maybe_async(obj: Awaitable[T] | T) -> T:
-    return cast(T, await obj) if inspect.isawaitable(obj) else cast(T, obj)
-
-
-def maybe_async_cm(obj: AbstractContextManager[T] | AbstractAsyncContextManager[T]) -> AbstractAsyncContextManager[T]:
-    if isinstance(obj, AbstractContextManager):
-        return cast(AbstractAsyncContextManager[T], _ContextManagerWrapper(obj))
-    return obj
-
-
-def wrap_sync(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
-    if inspect.iscoroutinefunction(fn):
-        return fn
-
-    async def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-        return await anyio.to_thread.run_sync(partial(fn, *args, **kwargs))
-
-    return wrapped
 
 
 def simple_string_hash(string_to_hash: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,3 @@ root_path = here.parent
 pytest_plugins = [
     "pytest_databases.docker",
 ]
-
-
-@pytest.fixture(scope="session")
-def anyio_backend() -> str:
-    return "asyncio"

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_databases.docker.alloydb_omni import alloydb_omni_responsive
 
 if TYPE_CHECKING:
-    import asyncpg
+    import psycopg
 
     from pytest_databases.docker import DockerServiceRegistry
 
@@ -17,7 +17,7 @@ pytest_plugins = [
 ]
 
 
-async def test_alloydb_omni_default_config(
+def test_alloydb_omni_default_config(
     default_alloydb_omni_service_name: str,
     alloydb_omni_port: int,
     postgres_database: str,
@@ -31,7 +31,7 @@ async def test_alloydb_omni_default_config(
     assert postgres_password == "super-secret"
 
 
-async def test_alloydb_omni_services(
+def test_alloydb_omni_services(
     alloydb_docker_ip: str,
     alloydb_omni_service: DockerServiceRegistry,
     alloydb_omni_port: int,
@@ -39,7 +39,7 @@ async def test_alloydb_omni_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await alloydb_omni_responsive(
+    ping = alloydb_omni_responsive(
         alloydb_docker_ip,
         port=alloydb_omni_port,
         database=postgres_database,
@@ -49,9 +49,9 @@ async def test_alloydb_omni_services(
     assert ping
 
 
-async def test_alloydb_omni_service_after_start(
-    postgres_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_alloydb_omni_service_after_start(
+    postgres_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres_startup_connection.fetchrow("select * from simple_table")
+    postgres_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
+pytestmark = pytest.mark.skip
 pytest_plugins = [
     "pytest_databases.docker.alloydb_omni",
 ]

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pytest_databases.docker.alloydb_omni import alloydb_omni_responsive
+import pytest
 
 if TYPE_CHECKING:
     import psycopg
 
     from pytest_databases.docker import DockerServiceRegistry
+
+
+pytestmark = pytest.mark.skip
 
 pytest_plugins = [
     "pytest_databases.docker.alloydb_omni",

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.alloydb_omni import alloydb_omni_responsive
 
 if TYPE_CHECKING:
@@ -11,7 +9,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.skip
 pytest_plugins = [
     "pytest_databases.docker.alloydb_omni",
 ]

--- a/tests/docker/test_alloydb_omni.py
+++ b/tests/docker/test_alloydb_omni.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pytest_databases.docker.alloydb_omni import alloydb_omni_responsive
 import pytest
+
+from pytest_databases.docker.alloydb_omni import alloydb_omni_responsive
 
 if TYPE_CHECKING:
     import psycopg

--- a/tests/docker/test_azure_blob.py
+++ b/tests/docker/test_azure_blob.py
@@ -9,5 +9,5 @@ pytest_plugins = [
 ]
 
 
-async def test_azure_blob_service(azure_blob_container_client: ContainerClient) -> None:
+def test_azure_blob_service(azure_blob_container_client: ContainerClient) -> None:
     assert not azure_blob_container_client.exists()

--- a/tests/docker/test_azure_blob.py
+++ b/tests/docker/test_azure_blob.py
@@ -1,8 +1,4 @@
-import pytest
 from azure.storage.blob import ContainerClient
-
-pytestmark = pytest.mark.anyio
-
 
 pytest_plugins = [
     "pytest_databases.docker.azure_blob",

--- a/tests/docker/test_bigquery.py
+++ b/tests/docker/test_bigquery.py
@@ -34,7 +34,7 @@ def test_bigquery_default_config(
     assert bigquery_project == "emulator-test-project"
 
 
-async def test_bigquery_services(
+def test_bigquery_services(
     bigquery_docker_ip: str,
     bigquery_service: DockerServiceRegistry,
     bigquery_endpoint: str,
@@ -43,7 +43,7 @@ async def test_bigquery_services(
     bigquery_project: str,
     bigquery_credentials: Credentials,
 ) -> None:
-    ping = await bigquery_responsive(
+    ping = bigquery_responsive(
         bigquery_docker_ip,
         bigquery_endpoint=bigquery_endpoint,
         bigquery_dataset=bigquery_dataset,
@@ -54,7 +54,7 @@ async def test_bigquery_services(
     assert ping
 
 
-async def test_bigquery_service_after_start(
+def test_bigquery_service_after_start(
     bigquery_startup_connection: bigquery.Client,
 ) -> None:
     assert isinstance(bigquery_startup_connection, bigquery.Client)

--- a/tests/docker/test_bigquery.py
+++ b/tests/docker/test_bigquery.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from google.cloud import bigquery
 
 from pytest_databases.docker.bigquery import bigquery_responsive
@@ -13,7 +12,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.bigquery",
 ]

--- a/tests/docker/test_cockroachdb.py
+++ b/tests/docker/test_cockroachdb.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.cockroachdb import cockroachdb_responsive
 
 if TYPE_CHECKING:
@@ -11,7 +9,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.cockroachdb",
 ]

--- a/tests/docker/test_cockroachdb.py
+++ b/tests/docker/test_cockroachdb.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_databases.docker.cockroachdb import cockroachdb_responsive
 
 if TYPE_CHECKING:
-    import asyncpg
+    import psycopg
 
     from pytest_databases.docker import DockerServiceRegistry
 
@@ -25,22 +25,22 @@ def test_cockroachdb_default_config(
     assert cockroachdb_driver_opts == {"sslmode": "disable"}
 
 
-async def test_cockroachdb_service(
+def test_cockroachdb_service(
     cockroachdb_docker_ip: str,
     cockroachdb_service: DockerServiceRegistry,
     cockroachdb_database: str,
     cockroachdb_port: int,
     cockroachdb_driver_opts: dict[str, str],
 ) -> None:
-    ping = await cockroachdb_responsive(
+    ping = cockroachdb_responsive(
         cockroachdb_docker_ip, cockroachdb_port, cockroachdb_database, cockroachdb_driver_opts
     )
     assert ping
 
 
-async def test_cockroachdb_services_after_start(
-    cockroachdb_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_cockroachdb_services_after_start(
+    cockroachdb_startup_connection: psycopg.Connection,
 ) -> None:
-    await cockroachdb_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-    result = await cockroachdb_startup_connection.fetchrow("select * from simple_table")
+    cockroachdb_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+    result = cockroachdb_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)

--- a/tests/docker/test_dragonfly.py
+++ b/tests/docker/test_dragonfly.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_databases.docker.dragonfly import dragonfly_responsive
+from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
@@ -19,10 +19,12 @@ def test_dragonfly_default_config(dragonfly_port: int) -> None:
     assert dragonfly_port == 6398
 
 
-async def test_dragonfly_service(
+def test_dragonfly_service(
     dragonfly_docker_ip: str,
     dragonfly_service: DockerServiceRegistry,
     dragonfly_port: int,
 ) -> None:
-    ping = await dragonfly_responsive(dragonfly_docker_ip, dragonfly_port)
+    ping = redis_responsive(dragonfly_docker_ip, dragonfly_port)
     assert ping
+
+

--- a/tests/docker/test_dragonfly.py
+++ b/tests/docker/test_dragonfly.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.dragonfly",
 ]

--- a/tests/docker/test_dragonfly.py
+++ b/tests/docker/test_dragonfly.py
@@ -26,5 +26,3 @@ def test_dragonfly_service(
 ) -> None:
     ping = redis_responsive(dragonfly_docker_ip, dragonfly_port)
     assert ping
-
-

--- a/tests/docker/test_elasticsearch.py
+++ b/tests/docker/test_elasticsearch.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
 from unittest import mock
 
 import pytest
-from elasticsearch7 import AsyncElasticsearch as Elasticsearch7
-from elasticsearch8 import AsyncElasticsearch as Elasticsearch8
+from elasticsearch7 import Elasticsearch as Elasticsearch7
+from elasticsearch8 import Elasticsearch as Elasticsearch8
 
 from pytest_databases.docker.elastic_search import elasticsearch7_responsive, elasticsearch8_responsive
 
@@ -21,7 +21,7 @@ pytest_plugins = [
 
 
 @pytest.fixture
-async def elasticsearch7_service(
+def elasticsearch7_service(
     elasticsearch_docker_services: DockerServiceRegistry,
     elasticsearch_docker_compose_files: list[Path],
     elasticsearch7_port: int,
@@ -32,7 +32,7 @@ async def elasticsearch7_service(
 ) -> AsyncGenerator[Any, Any]:
     """Overwrites fixture to stop container after the test."""
     try:
-        await elasticsearch_docker_services.start(
+        elasticsearch_docker_services.start(
             "elasticsearch7",
             docker_compose_files=elasticsearch_docker_compose_files,
             timeout=45,
@@ -50,7 +50,7 @@ async def elasticsearch7_service(
 
 
 @pytest.fixture
-async def elasticsearch8_service(
+def elasticsearch8_service(
     elasticsearch_docker_services: DockerServiceRegistry,
     elasticsearch_docker_compose_files: list[Path],
     elasticsearch8_port: int,
@@ -61,7 +61,7 @@ async def elasticsearch8_service(
 ) -> AsyncGenerator[Any, Any]:
     """Overwrites fixture to stop container after the test."""
     try:
-        await elasticsearch_docker_services.start(
+        elasticsearch_docker_services.start(
             "elasticsearch8",
             docker_compose_files=elasticsearch_docker_compose_files,
             timeout=45,
@@ -96,7 +96,7 @@ def test_elasticsearch8_default_config(
     assert elasticsearch_scheme == "http"
 
 
-async def test_elasticsearch7_service(
+def test_elasticsearch7_service(
     elasticsearch_docker_ip: str,
     elasticsearch7_service: DockerServiceRegistry,
     elasticsearch7_port: str,
@@ -104,17 +104,17 @@ async def test_elasticsearch7_service(
     elasticsearch_password: str,
     elasticsearch_scheme: str,
 ) -> None:
-    async with Elasticsearch7(
+    with Elasticsearch7(
         hosts=[{"host": elasticsearch_docker_ip, "port": elasticsearch7_port, "scheme": elasticsearch_scheme}],
         verify_certs=False,
         http_auth=(elasticsearch_user, elasticsearch_password),
     ) as client:
-        info = await client.info()
+        info = client.info()
 
     assert info["version"]["number"] == "7.17.19"
 
 
-async def test_elasticsearch8_service(
+def test_elasticsearch8_service(
     elasticsearch_docker_ip: str,
     elasticsearch8_service: DockerServiceRegistry,
     elasticsearch8_port: str,
@@ -122,12 +122,12 @@ async def test_elasticsearch8_service(
     elasticsearch_password: str,
     elasticsearch_scheme: str,
 ) -> None:
-    async with Elasticsearch8(
+    with Elasticsearch8(
         hosts=[{"host": elasticsearch_docker_ip, "port": elasticsearch8_port, "scheme": elasticsearch_scheme}],
         verify_certs=False,
         basic_auth=(elasticsearch_user, elasticsearch_password),
     ) as client:
-        info = await client.info()
+        info = client.info()
 
     assert info["version"]["number"] == "8.13.0"
 
@@ -139,6 +139,6 @@ async def test_elasticsearch8_service(
         (elasticsearch8_responsive, "pytest_databases.docker.elastic_search.Elasticsearch8.ping"),
     ),
 )
-async def test_elasticsearch_responsive(responsive: Callable, path_to_mock: str) -> None:
+def test_elasticsearch_responsive(responsive: Callable, path_to_mock: str) -> None:
     with mock.patch(path_to_mock, mock.Mock(side_effect=Exception)):
-        assert not await responsive(scheme="", host="", port="", user="", password="", database="")
+        assert not responsive(scheme="", host="", port="", user="", password="", database="")

--- a/tests/docker/test_elasticsearch.py
+++ b/tests/docker/test_elasticsearch.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.elastic_search",
 ]

--- a/tests/docker/test_elasticsearch.py
+++ b/tests/docker/test_elasticsearch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Callable, Generator
 from unittest import mock
 
 import pytest
@@ -29,7 +29,7 @@ def elasticsearch7_service(
     elasticsearch_user: str,
     elasticsearch_password: str,
     elasticsearch_scheme: str,
-) -> AsyncGenerator[Any, Any]:
+) -> Generator[None, None, None]:
     """Overwrites fixture to stop container after the test."""
     try:
         elasticsearch_docker_services.start(
@@ -58,7 +58,7 @@ def elasticsearch8_service(
     elasticsearch_user: str,
     elasticsearch_password: str,
     elasticsearch_scheme: str,
-) -> AsyncGenerator[Any, Any]:
+) -> Generator[None, None, None]:
     """Overwrites fixture to stop container after the test."""
     try:
         elasticsearch_docker_services.start(

--- a/tests/docker/test_keydb.py
+++ b/tests/docker/test_keydb.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.keydb",
 ]

--- a/tests/docker/test_keydb.py
+++ b/tests/docker/test_keydb.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_databases.docker.keydb import keydb_responsive
+from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
@@ -19,10 +19,10 @@ def test_keydb_default_config(keydb_port: int) -> None:
     assert keydb_port == 6396
 
 
-async def test_keydb_service(
+def test_keydb_service(
     keydb_docker_ip: str,
     keydb_service: DockerServiceRegistry,
     keydb_port: int,
 ) -> None:
-    ping = await keydb_responsive(keydb_docker_ip, keydb_port)
+    ping = redis_responsive(keydb_docker_ip, keydb_port)
     assert ping

--- a/tests/docker/test_mariadb.py
+++ b/tests/docker/test_mariadb.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from pytest_databases.docker.mariadb import mariadb_responsive
+from pytest_databases.docker.mysql import mysql_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
@@ -15,7 +15,7 @@ pytest_plugins = [
 ]
 
 
-async def test_mariadb_default_config(
+def test_mariadb_default_config(
     default_mariadb_service_name: str,
     mariadb_port: int,
     mariadb_database: str,
@@ -29,7 +29,7 @@ async def test_mariadb_default_config(
     assert mariadb_password == "super-secret"
 
 
-async def test_mariadb_113_config(
+def test_mariadb_113_config(
     mariadb113_port: int,
     mariadb_database: str,
     mariadb_user: str,
@@ -41,7 +41,7 @@ async def test_mariadb_113_config(
     assert mariadb_password == "super-secret"
 
 
-async def test_mariadb_services(
+def test_mariadb_services(
     mariadb_docker_ip: str,
     mariadb_service: DockerServiceRegistry,
     mariadb_port: int,
@@ -49,7 +49,7 @@ async def test_mariadb_services(
     mariadb_user: str,
     mariadb_password: str,
 ) -> None:
-    ping = await mariadb_responsive(
+    ping = mysql_responsive(
         mariadb_docker_ip,
         port=mariadb_port,
         database=mariadb_database,
@@ -59,7 +59,7 @@ async def test_mariadb_services(
     assert ping
 
 
-async def test_mariadb_113_services(
+def test_mariadb_113_services(
     mariadb_docker_ip: str,
     mariadb113_service: DockerServiceRegistry,
     mariadb113_port: int,
@@ -67,7 +67,7 @@ async def test_mariadb_113_services(
     mariadb_user: str,
     mariadb_password: str,
 ) -> None:
-    ping = await mariadb_responsive(
+    ping = mysql_responsive(
         mariadb_docker_ip,
         port=mariadb113_port,
         database=mariadb_database,
@@ -77,21 +77,21 @@ async def test_mariadb_113_services(
     assert ping
 
 
-async def test_mariadb_services_after_start(
+def test_mariadb_services_after_start(
     mariadb_startup_connection: Any,
 ) -> None:
-    async with mariadb_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mariadb_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_mariadb113_services_after_start(
+def test_mariadb113_services_after_start(
     mariadb113_startup_connection: Any,
 ) -> None:
-    async with mariadb113_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mariadb113_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)

--- a/tests/docker/test_mariadb.py
+++ b/tests/docker/test_mariadb.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pytest
-
 from pytest_databases.docker.mysql import mysql_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
+
 pytest_plugins = [
     "pytest_databases.docker.mariadb",
 ]

--- a/tests/docker/test_mssql.py
+++ b/tests/docker/test_mssql.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.mssql import mssql_responsive
 
 if TYPE_CHECKING:
@@ -11,7 +9,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.mssql",
 ]

--- a/tests/docker/test_mssql.py
+++ b/tests/docker/test_mssql.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_databases.docker.mssql import mssql_responsive
 
 if TYPE_CHECKING:
-    import aioodbc
+    import pyodbc
 
     from pytest_databases.docker import DockerServiceRegistry
 
@@ -17,7 +17,7 @@ pytest_plugins = [
 ]
 
 
-async def test_mssql_default_config(
+def test_mssql_default_config(
     default_mssql_service_name: str,
     mssql_port: int,
     mssql_database: str,
@@ -31,7 +31,7 @@ async def test_mssql_default_config(
     assert mssql_password == "Super-secret1"
 
 
-async def test_mssql_2022_config(
+def test_mssql_2022_config(
     mssql2022_port: int,
     mssql_database: str,
     mssql_user: str,
@@ -43,7 +43,7 @@ async def test_mssql_2022_config(
     assert mssql_password == "Super-secret1"
 
 
-async def test_mssql_services(
+def test_mssql_services(
     mssql_docker_ip: str,
     mssql_service: DockerServiceRegistry,
     mssql_port: int,
@@ -53,11 +53,11 @@ async def test_mssql_services(
 ) -> None:
     connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
 
-    ping = await mssql_responsive(mssql_docker_ip, connstring=connstring)
+    ping = mssql_responsive(mssql_docker_ip, connstring=connstring)
     assert ping
 
 
-async def test_mssql_2022_services(
+def test_mssql_2022_services(
     mssql_docker_ip: str,
     mssql2022_service: DockerServiceRegistry,
     mssql2022_port: int,
@@ -67,27 +67,27 @@ async def test_mssql_2022_services(
 ) -> None:
     connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql2022_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
 
-    ping = await mssql_responsive(mssql_docker_ip, connstring=connstring)
+    ping = mssql_responsive(mssql_docker_ip, connstring=connstring)
     assert ping
 
 
-async def test_mssql_services_after_start(
-    mssql_startup_connection: aioodbc.Connection,
+def test_mssql_services_after_start(
+    mssql_startup_connection: pyodbc.Connection,
 ) -> None:
-    async with mssql_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE view simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mssql_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE view simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
-        await cursor.execute("drop view simple_table")
+        cursor.execute("drop view simple_table")
 
 
 async def test_mssql2022_services_after_start(
-    mssql2022_startup_connection: aioodbc.Connection,
+    mssql2022_startup_connection: pyodbc.Connection,
 ) -> None:
-    async with mssql2022_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE view simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mssql2022_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE view simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
-        await cursor.execute("drop view simple_table")
+        cursor.execute("drop view simple_table")

--- a/tests/docker/test_mssql.py
+++ b/tests/docker/test_mssql.py
@@ -51,9 +51,13 @@ def test_mssql_services(
     mssql_user: str,
     mssql_password: str,
 ) -> None:
-    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
-
-    ping = mssql_responsive(mssql_docker_ip, connstring=connstring)
+    ping = mssql_responsive(
+        mssql_docker_ip,
+        port=mssql_port,
+        database=mssql_database,
+        user=mssql_user,
+        password=mssql_password,
+    )
     assert ping
 
 
@@ -65,9 +69,13 @@ def test_mssql_2022_services(
     mssql_user: str,
     mssql_password: str,
 ) -> None:
-    connstring = f"encrypt=no; TrustServerCertificate=yes; driver={{ODBC Driver 18 for SQL Server}}; server={mssql_docker_ip},{mssql2022_port}; database={mssql_database}; UID={mssql_user}; PWD={mssql_password}"
-
-    ping = mssql_responsive(mssql_docker_ip, connstring=connstring)
+    ping = mssql_responsive(
+        mssql_docker_ip,
+        port=mssql2022_port,
+        database=mssql_database,
+        user=mssql_user,
+        password=mssql_password,
+    )
     assert ping
 
 

--- a/tests/docker/test_mysql.py
+++ b/tests/docker/test_mysql.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 ]
 
 
-async def test_mysql_default_config(
+def test_mysql_default_config(
     default_mysql_service_name: str,
     mysql_port: int,
     mysql_database: str,
@@ -29,7 +29,7 @@ async def test_mysql_default_config(
     assert mysql_password == "super-secret"
 
 
-async def test_mysql_8_config(
+def test_mysql_8_config(
     mysql8_port: int,
     mysql_database: str,
     mysql_user: str,
@@ -41,7 +41,7 @@ async def test_mysql_8_config(
     assert mysql_password == "super-secret"
 
 
-async def test_mysql_57_config(
+def test_mysql_57_config(
     mysql57_port: int,
     mysql_database: str,
     mysql_user: str,
@@ -53,7 +53,7 @@ async def test_mysql_57_config(
     assert mysql_password == "super-secret"
 
 
-async def test_mysql_56_config(
+def test_mysql_56_config(
     mysql56_port: int,
     mysql_database: str,
     mysql_user: str,
@@ -65,7 +65,7 @@ async def test_mysql_56_config(
     assert mysql_password == "super-secret"
 
 
-async def test_mysql_services(
+def test_mysql_services(
     mysql_docker_ip: str,
     mysql_service: DockerServiceRegistry,
     mysql_port: int,
@@ -73,7 +73,7 @@ async def test_mysql_services(
     mysql_user: str,
     mysql_password: str,
 ) -> None:
-    ping = await mysql_responsive(
+    ping = mysql_responsive(
         mysql_docker_ip,
         port=mysql_port,
         database=mysql_database,
@@ -83,7 +83,7 @@ async def test_mysql_services(
     assert ping
 
 
-async def test_mysql_57_services(
+def test_mysql_57_services(
     mysql_docker_ip: str,
     mysql57_service: DockerServiceRegistry,
     mysql57_port: int,
@@ -91,7 +91,7 @@ async def test_mysql_57_services(
     mysql_user: str,
     mysql_password: str,
 ) -> None:
-    ping = await mysql_responsive(
+    ping = mysql_responsive(
         mysql_docker_ip,
         port=mysql57_port,
         database=mysql_database,
@@ -101,7 +101,7 @@ async def test_mysql_57_services(
     assert ping
 
 
-async def test_mysql_56_services(
+def test_mysql_56_services(
     mysql_docker_ip: str,
     mysql56_service: DockerServiceRegistry,
     mysql56_port: int,
@@ -109,7 +109,7 @@ async def test_mysql_56_services(
     mysql_user: str,
     mysql_password: str,
 ) -> None:
-    ping = await mysql_responsive(
+    ping = mysql_responsive(
         mysql_docker_ip,
         port=mysql56_port,
         database=mysql_database,
@@ -119,7 +119,7 @@ async def test_mysql_56_services(
     assert ping
 
 
-async def test_mysql_8_services(
+def test_mysql_8_services(
     mysql_docker_ip: str,
     mysql8_service: DockerServiceRegistry,
     mysql8_port: int,
@@ -127,7 +127,7 @@ async def test_mysql_8_services(
     mysql_user: str,
     mysql_password: str,
 ) -> None:
-    ping = await mysql_responsive(
+    ping = mysql_responsive(
         mysql_docker_ip,
         port=mysql8_port,
         database=mysql_database,
@@ -137,41 +137,41 @@ async def test_mysql_8_services(
     assert ping
 
 
-async def test_mysql_services_after_start(
+def test_mysql_services_after_start(
     mysql_startup_connection: Any,
 ) -> None:
-    async with mysql_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mysql_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_mysql56_services_after_start(
+def test_mysql56_services_after_start(
     mysql56_startup_connection: Any,
 ) -> None:
-    async with mysql56_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mysql56_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_mysql57_services_after_start(
+def test_mysql57_services_after_start(
     mysql57_startup_connection: Any,
 ) -> None:
-    async with mysql57_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mysql57_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_mysql8_services_after_start(
+def test_mysql8_services_after_start(
     mysql8_startup_connection: Any,
 ) -> None:
-    async with mysql8_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with mysql8_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)

--- a/tests/docker/test_mysql.py
+++ b/tests/docker/test_mysql.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pytest
-
 from pytest_databases.docker.mysql import mysql_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.mysql",
 ]

--- a/tests/docker/test_mysql.py
+++ b/tests/docker/test_mysql.py
@@ -62,24 +62,6 @@ def test_mysql_56_config(
     assert mysql_password == "super-secret"
 
 
-def test_mysql_services(
-    mysql_docker_ip: str,
-    mysql_service: DockerServiceRegistry,
-    mysql_port: int,
-    mysql_database: str,
-    mysql_user: str,
-    mysql_password: str,
-) -> None:
-    ping = mysql_responsive(
-        mysql_docker_ip,
-        port=mysql_port,
-        database=mysql_database,
-        user=mysql_user,
-        password=mysql_password,
-    )
-    assert ping
-
-
 def test_mysql_57_services(
     mysql_docker_ip: str,
     mysql57_service: DockerServiceRegistry,

--- a/tests/docker/test_oracle.py
+++ b/tests/docker/test_oracle.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import oracledb
-import pytest
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.oracle",
 ]

--- a/tests/docker/test_oracle.py
+++ b/tests/docker/test_oracle.py
@@ -89,10 +89,10 @@ def test_oracle23ai_service(
 def test_oracle_services_after_start(
     oracle_startup_connection: oracledb.Connection,
 ) -> None:
-     with oracle_startup_connection.cursor() as cursor:
+    with oracle_startup_connection.cursor() as cursor:
         cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
         cursor.execute("select * from simple_table")
-        result =  cursor.fetchall()
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 

--- a/tests/docker/test_oracle.py
+++ b/tests/docker/test_oracle.py
@@ -48,7 +48,7 @@ def test_oracle_default_config(
     assert oracle_port == oracle23ai_port
 
 
-async def test_oracle18c_service(
+def test_oracle18c_service(
     oracle_docker_ip: str,
     oracle18c_service: DockerServiceRegistry,
     oracle18c_service_name: str,
@@ -67,7 +67,7 @@ async def test_oracle18c_service(
         assert "Hello World!" in res
 
 
-async def test_oracle23ai_service(
+def test_oracle23ai_service(
     oracle_docker_ip: str,
     oracle23ai_service: DockerServiceRegistry,
     oracle23ai_service_name: str,
@@ -86,31 +86,31 @@ async def test_oracle23ai_service(
         assert "Hello World!" in res
 
 
-async def test_oracle_services_after_start(
-    oracle_startup_connection: oracledb.AsyncConnection,
+def test_oracle_services_after_start(
+    oracle_startup_connection: oracledb.Connection,
 ) -> None:
-    async with oracle_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+     with oracle_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
+        cursor.execute("select * from simple_table")
+        result =  cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_oracle18c_services_after_start(
-    oracle18c_startup_connection: oracledb.AsyncConnection,
+def test_oracle18c_services_after_start(
+    oracle18c_startup_connection: oracledb.Connection,
 ) -> None:
-    async with oracle18c_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with oracle18c_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)
 
 
-async def test_oracle23ai_services_after_start(
-    oracle23ai_startup_connection: oracledb.AsyncConnection,
+def test_oracle23ai_services_after_start(
+    oracle23ai_startup_connection: oracledb.Connection,
 ) -> None:
-    async with oracle23ai_startup_connection.cursor() as cursor:
-        await cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
-        await cursor.execute("select * from simple_table")
-        result = await cursor.fetchall()
+    with oracle23ai_startup_connection.cursor() as cursor:
+        cursor.execute("CREATE or replace view simple_table as SELECT 1 as the_value from dual")
+        cursor.execute("select * from simple_table")
+        result = cursor.fetchall()
         assert bool(result is not None and result[0][0] == 1)

--- a/tests/docker/test_postgres.py
+++ b/tests/docker/test_postgres.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.postgres import postgres_responsive
 
 if TYPE_CHECKING:
@@ -11,7 +9,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = [pytest.mark.anyio, pytest.mark.postgres]
 pytest_plugins = [
     "pytest_databases.docker.postgres",
 ]

--- a/tests/docker/test_postgres.py
+++ b/tests/docker/test_postgres.py
@@ -7,17 +7,17 @@ import pytest
 from pytest_databases.docker.postgres import postgres_responsive
 
 if TYPE_CHECKING:
-    import asyncpg
+    import psycopg
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
+pytestmark = [pytest.mark.anyio, pytest.mark.postgres]
 pytest_plugins = [
     "pytest_databases.docker.postgres",
 ]
 
 
-async def test_postgres_default_config(
+def test_postgres_default_config(
     default_postgres_service_name: str,
     postgres_port: int,
     postgres_database: str,
@@ -31,7 +31,7 @@ async def test_postgres_default_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_12_config(
+def test_postgres_12_config(
     postgres12_port: int,
     postgres_database: str,
     postgres_user: str,
@@ -43,7 +43,7 @@ async def test_postgres_12_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_13_config(
+def test_postgres_13_config(
     postgres13_port: int,
     postgres_database: str,
     postgres_user: str,
@@ -55,7 +55,7 @@ async def test_postgres_13_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_14_config(
+def test_postgres_14_config(
     postgres14_port: int,
     postgres_database: str,
     postgres_user: str,
@@ -67,7 +67,7 @@ async def test_postgres_14_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_15_config(
+def test_postgres_15_config(
     postgres15_port: int,
     postgres_database: str,
     postgres_user: str,
@@ -79,7 +79,7 @@ async def test_postgres_15_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_16_config(
+def test_postgres_16_config(
     postgres16_port: int,
     postgres_database: str,
     postgres_user: str,
@@ -91,7 +91,7 @@ async def test_postgres_16_config(
     assert postgres_password == "super-secret"
 
 
-async def test_postgres_services(
+def test_postgres_services(
     postgres_docker_ip: str,
     postgres_service: DockerServiceRegistry,
     postgres_port: int,
@@ -99,7 +99,7 @@ async def test_postgres_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres_port,
         database=postgres_database,
@@ -109,7 +109,7 @@ async def test_postgres_services(
     assert ping
 
 
-async def test_postgres_12_services(
+def test_postgres_12_services(
     postgres_docker_ip: str,
     postgres12_service: DockerServiceRegistry,
     postgres12_port: int,
@@ -117,7 +117,7 @@ async def test_postgres_12_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres12_port,
         database=postgres_database,
@@ -127,7 +127,7 @@ async def test_postgres_12_services(
     assert ping
 
 
-async def test_postgres_13_services(
+def test_postgres_13_services(
     postgres_docker_ip: str,
     postgres13_service: DockerServiceRegistry,
     postgres13_port: int,
@@ -135,7 +135,7 @@ async def test_postgres_13_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres13_port,
         database=postgres_database,
@@ -145,7 +145,7 @@ async def test_postgres_13_services(
     assert ping
 
 
-async def test_postgres_14_services(
+def test_postgres_14_services(
     postgres_docker_ip: str,
     postgres14_service: DockerServiceRegistry,
     postgres14_port: int,
@@ -153,7 +153,7 @@ async def test_postgres_14_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres14_port,
         database=postgres_database,
@@ -163,7 +163,7 @@ async def test_postgres_14_services(
     assert ping
 
 
-async def test_postgres_15_services(
+def test_postgres_15_services(
     postgres_docker_ip: str,
     postgres15_service: DockerServiceRegistry,
     postgres15_port: int,
@@ -171,7 +171,7 @@ async def test_postgres_15_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres15_port,
         database=postgres_database,
@@ -181,7 +181,7 @@ async def test_postgres_15_services(
     assert ping
 
 
-async def test_postgres_16_services(
+def test_postgres_16_services(
     postgres_docker_ip: str,
     postgres16_service: DockerServiceRegistry,
     postgres16_port: int,
@@ -189,7 +189,7 @@ async def test_postgres_16_services(
     postgres_user: str,
     postgres_password: str,
 ) -> None:
-    ping = await postgres_responsive(
+    ping = postgres_responsive(
         postgres_docker_ip,
         port=postgres16_port,
         database=postgres_database,
@@ -199,49 +199,49 @@ async def test_postgres_16_services(
     assert ping
 
 
-async def test_postgres_services_after_start(
-    postgres_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_services_after_start(
+    postgres_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres_startup_connection.fetchrow("select * from simple_table")
+    postgres_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)
 
 
-async def test_postgres_16_services_after_start(
-    postgres16_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_16_services_after_start(
+    postgres16_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres16_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres16_startup_connection.fetchrow("select * from simple_table")
+    postgres16_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres16_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)
 
 
-async def test_postgres_15_services_after_start(
-    postgres15_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_15_services_after_start(
+    postgres15_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres15_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres15_startup_connection.fetchrow("select * from simple_table")
+    postgres15_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres15_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)
 
 
-async def test_postgres_14_services_after_start(
-    postgres14_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_14_services_after_start(
+    postgres14_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres14_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres14_startup_connection.fetchrow("select * from simple_table")
+    postgres14_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres14_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)
 
 
-async def test_postgres_13_services_after_start(
-    postgres13_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_13_services_after_start(
+    postgres13_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres13_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres13_startup_connection.fetchrow("select * from simple_table")
+    postgres13_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres13_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)
 
 
-async def test_postgres_12_services_after_start(
-    postgres12_startup_connection: asyncpg.Connection[asyncpg.Record],
+def test_postgres_12_services_after_start(
+    postgres12_startup_connection: psycopg.Connection,
 ) -> None:
-    await postgres12_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = await postgres12_startup_connection.fetchrow("select * from simple_table")
+    postgres12_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
+    result = postgres12_startup_connection.execute("select * from simple_table").fetchone()
     assert bool(result is not None and result[0] == 1)

--- a/tests/docker/test_postgres.py
+++ b/tests/docker/test_postgres.py
@@ -199,14 +199,6 @@ def test_postgres_16_services(
     assert ping
 
 
-def test_postgres_services_after_start(
-    postgres_startup_connection: psycopg.Connection,
-) -> None:
-    postgres_startup_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-    result = postgres_startup_connection.execute("select * from simple_table").fetchone()
-    assert bool(result is not None and result[0] == 1)
-
-
 def test_postgres_16_services_after_start(
     postgres16_startup_connection: psycopg.Connection,
 ) -> None:

--- a/tests/docker/test_redis.py
+++ b/tests/docker/test_redis.py
@@ -19,10 +19,19 @@ def test_redis_default_config(redis_port: int) -> None:
     assert redis_port == 6397
 
 
-async def test_redis_service(
+def test_redis_service(
     redis_docker_ip: str,
     redis_service: DockerServiceRegistry,
     redis_port: int,
 ) -> None:
-    ping = await redis_responsive(redis_docker_ip, redis_port)
+    ping = redis_responsive(redis_docker_ip, redis_port)
+    assert ping
+
+
+async def test_redis_service_async(
+    redis_docker_ip: str,
+    redis_service: DockerServiceRegistry,
+    redis_port: int,
+) -> None:
+    ping = redis_responsive(redis_docker_ip, redis_port)
     assert ping

--- a/tests/docker/test_redis.py
+++ b/tests/docker/test_redis.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.redis import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.redis",
 ]
@@ -20,15 +17,6 @@ def test_redis_default_config(redis_port: int) -> None:
 
 
 def test_redis_service(
-    redis_docker_ip: str,
-    redis_service: DockerServiceRegistry,
-    redis_port: int,
-) -> None:
-    ping = redis_responsive(redis_docker_ip, redis_port)
-    assert ping
-
-
-async def test_redis_service_async(
     redis_docker_ip: str,
     redis_service: DockerServiceRegistry,
     redis_port: int,

--- a/tests/docker/test_spanner.py
+++ b/tests/docker/test_spanner.py
@@ -18,7 +18,7 @@ pytest_plugins = [
 ]
 
 
-async def test_spanner_default_config(
+def test_spanner_default_config(
     spanner_port: int, spanner_instance: str, spanner_database: str, spanner_project: str
 ) -> None:
     assert spanner_port == 9010
@@ -27,7 +27,7 @@ async def test_spanner_default_config(
     assert spanner_project == "emulator-test-project"
 
 
-async def test_spanner_services(
+def test_spanner_services(
     spanner_docker_ip: str,
     spanner_service: DockerServiceRegistry,
     spanner_port: int,
@@ -47,7 +47,7 @@ async def test_spanner_services(
     assert ping
 
 
-async def test_spanner_service_after_start(
+def test_spanner_service_after_start(
     spanner_startup_connection: spanner.Client,
 ) -> None:
     assert isinstance(spanner_startup_connection, spanner.Client)

--- a/tests/docker/test_spanner.py
+++ b/tests/docker/test_spanner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from google.cloud import spanner
 
 from pytest_databases.docker.spanner import spanner_responsive
@@ -12,7 +11,6 @@ if TYPE_CHECKING:
 
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
 pytest_plugins = [
     "pytest_databases.docker.spanner",
 ]

--- a/tests/docker/test_valkey.py
+++ b/tests/docker/test_valkey.py
@@ -28,7 +28,6 @@ def test_valkey_service(
     assert ping
 
 
-
 async def test_valkey_service_async(
     valkey_docker_ip: str,
     valkey_service: DockerServiceRegistry,

--- a/tests/docker/test_valkey.py
+++ b/tests/docker/test_valkey.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_databases.docker.valkey import valkey_responsive
+from pytest_databases.docker.valkey import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
@@ -19,10 +19,20 @@ def test_valkey_default_config(valkey_port: int) -> None:
     assert valkey_port == 6308
 
 
-async def test_valkey_service(
+def test_valkey_service(
     valkey_docker_ip: str,
     valkey_service: DockerServiceRegistry,
     valkey_port: int,
 ) -> None:
-    ping = await valkey_responsive(valkey_docker_ip, valkey_port)
+    ping = redis_responsive(valkey_docker_ip, valkey_port)
+    assert ping
+
+
+
+async def test_valkey_service_async(
+    valkey_docker_ip: str,
+    valkey_service: DockerServiceRegistry,
+    valkey_port: int,
+) -> None:
+    ping = redis_responsive(valkey_docker_ip, valkey_port)
     assert ping

--- a/tests/docker/test_valkey.py
+++ b/tests/docker/test_valkey.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from pytest_databases.docker.valkey import redis_responsive
 
 if TYPE_CHECKING:
     from pytest_databases.docker import DockerServiceRegistry
 
-pytestmark = pytest.mark.anyio
+
 pytest_plugins = [
     "pytest_databases.docker.valkey",
 ]
@@ -20,15 +18,6 @@ def test_valkey_default_config(valkey_port: int) -> None:
 
 
 def test_valkey_service(
-    valkey_docker_ip: str,
-    valkey_service: DockerServiceRegistry,
-    valkey_port: int,
-) -> None:
-    ping = redis_responsive(valkey_docker_ip, valkey_port)
-    assert ping
-
-
-async def test_valkey_service_async(
     valkey_docker_ip: str,
     valkey_service: DockerServiceRegistry,
     valkey_port: int,


### PR DESCRIPTION
Remove the requirement for async pytest support.

Some drivers have changed:

- For `mssql`: `pymssql` > `aioodbc`
- For `mysql` / `mariadb`: `pymysql` > `asyncmy`
- For `postgres`: `psycopg` > `asyncpg`