### PR TITLE
feat: Enhance Postgres Services with configurable container host

### DIFF
--- a/docs/supported-databases/postgres.rst
+++ b/docs/supported-databases/postgres.rst
@@ -36,6 +36,7 @@ Usage Example
 Available Fixtures
 ------------------
 
+* ``postgres_host``: The PostgreSQL host address (defaults to "127.0.0.1", can be overridden with ``POSTGRES_HOST`` environment variable).
 * ``postgres_user``: The PostgreSQL user.
 * ``postgres_password``: The PostgreSQL password.
 * ``postgres_database``: The PostgreSQL database name to use.
@@ -55,6 +56,19 @@ The following version-specific fixtures are also available:
 * ``postgres_17_image``, ``postgres_17_service``, ``postgres_17_connection``: PostgreSQL 17.x
 * ``pgvector_image``, ``pgvector_service``. ``pgvector_connection``: Latest Available pgvector Docker image.
 
+Configuration
+-------------
+
+PostgreSQL services can be configured using environment variables:
+
+* ``POSTGRES_HOST``: The host address for the PostgreSQL container (default: "127.0.0.1")
+
+Example usage with custom host:
+
+.. code-block:: bash
+
+   export POSTGRES_HOST="192.168.1.100"
+   pytest
 
 Service API
 -----------

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import filelock
 import pytest
+from docker import DockerClient
 from docker.errors import APIError, ImageNotFound
 from typing_extensions import Self
 
-from docker import DockerClient
 from pytest_databases.helpers import get_xdist_worker_id
 from pytest_databases.types import ServiceContainer
 
@@ -126,6 +126,7 @@ class DockerService(AbstractContextManager):
         image: str,
         container_port: int,
         name: str,
+        container_host: str = "127.0.0.1",
         command: str | None = None,
         env: dict[str, Any] | None = None,
         exec_after_start: str | list[str] | None = None,
@@ -187,7 +188,7 @@ class DockerService(AbstractContextManager):
             container.ports[next(k for k in container.ports if k.startswith(str(container_port)))][0]["HostPort"]
         )
         service = ServiceContainer(
-            host="127.0.0.1",
+            host=container_host,
             port=host_port,
         )
 

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import filelock
 import pytest
-from docker import DockerClient
 from docker.errors import APIError, ImageNotFound
 from typing_extensions import Self
 
+from docker import DockerClient
 from pytest_databases.helpers import get_xdist_worker_id
 from pytest_databases.types import ServiceContainer
 

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -128,6 +128,7 @@ def postgres_11_service(
 def postgres_12_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -136,6 +137,7 @@ def postgres_12_service(
         image="postgres:12",
         name="postgres-12",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:

--- a/src/pytest_databases/docker/postgres.py
+++ b/src/pytest_databases/docker/postgres.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,11 @@ class PostgresService(ServiceContainer):
 
 
 @pytest.fixture(autouse=False, scope="session")
+def postgres_host() -> str:
+    return os.environ.get("POSTGRES_HOST", "127.0.0.1")
+
+
+@pytest.fixture(autouse=False, scope="session")
 def postgres_password() -> str:
     return "super-secret"
 
@@ -47,6 +53,7 @@ def _provide_postgres_service(
     docker_service: DockerService,
     image: str,
     name: str,
+    host: str,
     user: str,
     password: str,
     xdist_postgres_isolate: XdistIsolationLevel,
@@ -79,6 +86,7 @@ def _provide_postgres_service(
     with docker_service.run(
         image=image,
         check=check,
+        container_host=host,
         container_port=5432,
         name=name,
         env={
@@ -100,6 +108,7 @@ def _provide_postgres_service(
 def postgres_11_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -108,6 +117,7 @@ def postgres_11_service(
         image="postgres:11",
         name="postgres-11",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -136,6 +146,7 @@ def postgres_12_service(
 def postgres_13_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -144,6 +155,7 @@ def postgres_13_service(
         image="postgres:13",
         name="postgres-13",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -154,6 +166,7 @@ def postgres_13_service(
 def postgres_14_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -162,6 +175,7 @@ def postgres_14_service(
         image="postgres:14",
         name="postgres-14",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -172,6 +186,7 @@ def postgres_14_service(
 def postgres_15_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -180,6 +195,7 @@ def postgres_15_service(
         image="postgres:15",
         name="postgres-15",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -190,6 +206,7 @@ def postgres_15_service(
 def postgres_16_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -198,6 +215,7 @@ def postgres_16_service(
         image="postgres:16",
         name="postgres-16",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -208,6 +226,7 @@ def postgres_16_service(
 def postgres_17_service(
     docker_service: DockerService,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -216,6 +235,7 @@ def postgres_17_service(
         image="postgres:17",
         name="postgres-17",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -344,6 +364,7 @@ def postgres_service(
     docker_service: DockerService,
     postgres_image: str,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -352,6 +373,7 @@ def postgres_service(
         image=postgres_image,
         name="postgres",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -384,6 +406,7 @@ def pgvector_service(
     docker_service: DockerService,
     pgvector_image: str,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -392,6 +415,7 @@ def pgvector_service(
         image=pgvector_image,
         name="pgvector",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:
@@ -424,6 +448,7 @@ def alloydb_omni_service(
     docker_service: DockerService,
     pgvector_image: str,
     xdist_postgres_isolation_level: XdistIsolationLevel,
+    postgres_host: str,
     postgres_user: str,
     postgres_password: str,
 ) -> Generator[PostgresService, None, None]:
@@ -432,6 +457,7 @@ def alloydb_omni_service(
         image=pgvector_image,
         name="alloydb-omni",
         xdist_postgres_isolate=xdist_postgres_isolation_level,
+        host=postgres_host,
         user=postgres_user,
         password=postgres_password,
     ) as service:


### PR DESCRIPTION
## Description
- Added the `container_host` parameter to `DockerService` for flexibility. It defaults to `127.0.0.1`.
- Introduced a new `postgres_host` fixture to retrieve the host from environment variables if it is set.
- Updated PostgreSQL service functions to use the new host parameter.
- I did not update other database services, because I am not sure what the best way to set the host address for them is.

## Closes
This PR partially fixes #86.

I use docker-in-docker and see an error `ValueError: Service 'pytest_databases_postgres' failed to come online` when I try to run unit tests.

The root cause of the issue when using this library in the Docker-in-Docker case is the hardcoded `127.0.0.1` value as the container host. For Docker-in-Docker, it is necessary to use the `host.docker.internal` value. This PR allows setting the `POSTGRES_HOST` environment variable.

P.S. @cofin @peterHoburg @provinzkraut Thank you very much for this library! It seems to me more cool than `testcontainers` I used before.