### PR TITLE
fix: RuntimeError Cannot handle container in state created.

### DIFF
--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -64,7 +64,7 @@ def _stop_all_containers(client: DockerClient) -> None:
     for container in containers:
         if container.status == "running":
             container.kill()
-        elif container.status in {"stopped", "dead"}:
+        elif container.status in {"created", "stopped", "dead"}:
             container.remove()
         elif container.status == "removing":
             continue

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -69,7 +69,7 @@ def _stop_all_containers(client: DockerClient) -> None:
         try:
             if container.status == "running":
                 container.kill()
-            elif container.status in {"stopped", "dead"}:
+            elif container.status in {"created", "stopped", "dead"}:
                 container.remove()
             elif container.status == "removing":
                 continue


### PR DESCRIPTION
This PR fixes the RuntimeError: Cannot handle container in state created.

Containers in the state "created" are now removed in _service.py.

I am not sure why the container was stuck in the "created" state. In the debugger, I waited to see if it would transition into "running", but it didn’t.

Here is my call stack:  
<img width="1019" height="622" alt="grafik" src="https://github.com/user-attachments/assets/29def68c-c12e-4f66-948d-abd5c632b96b" />

