### PR TITLE
feat(mysql,mariadb): migrate to oneshot and add new versions

### DIFF
--- a/docs/supported-databases/mariadb.rst
+++ b/docs/supported-databases/mariadb.rst
@@ -3,15 +3,10 @@ MariaDB
 
 Integration with `MariaDB <https://mariadb.org>`_, a community-developed, commercially supported fork of the MySQL relational database management system.
 
-This integration uses the official `MariaDB Python Connector <https://mariadb.com/docs/clients/mariadb-connectors/connector-python/>`_ to interact with MariaDB.
-
 Installation
 ------------
 
-.. code-block:: bash
-
-   pip install pytest-databases[mariadb]
-
+MariaDB support is built-in and does not require any additional Python client libraries for basic service management. However, to connect to the database from your tests, you should install your preferred MariaDB client (e.g., `mariadb`).
 
 Usage Example
 -------------
@@ -25,6 +20,7 @@ Usage Example
     pytest_plugins = ["pytest_databases.docker.mariadb"]
 
     def test(mariadb_service: MariaDBService) -> None:
+        # Create your own connection using the service fixture attributes
         with mariadb.connect(
             host=mariadb_service.host,
             port=mariadb_service.port,
@@ -36,24 +32,19 @@ Usage Example
             resp = cursor.fetchone()
             assert resp is not None and resp[0] == 1
 
-    def test(mariadb_connection: mariadb.Connection) -> None:
-        with mariadb_connection.cursor() as cursor:
-            cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-            cursor.execute("select * from simple_table")
-            result = cursor.fetchall()
-            assert result is not None and result[0][0] == 1
-
 Available Fixtures
 ------------------
 
-* ``mariadb_service``: A fixture that provides a MariaDB service.
-* ``mariadb_connection``: A fixture that provides a MariaDB connection.
+* ``mariadb_service``: A fixture that provides a MariaDB service (11.4 LTS).
 
 The following version-specific fixtures are also available:
 
-* ``mariadb_113_service``: A fixture that provides a MariaDB 11.3 service.
-* ``mariadb_113_connection``: A fixture that provides a MariaDB 11.3 connection.
+* ``mariadb_113_service``: MariaDB 11.3
+* ``mariadb_114_service``: MariaDB 11.4 LTS
+* ``mariadb_122_service``: MariaDB 12.2 Rolling
 
+.. note::
+   The connection fixtures (e.g., ``mariadb_connection``, ``mariadb_114_connection``) are deprecated and will be removed in a future release. Users are encouraged to create their own connections as shown in the example above.
 
 Service API
 -----------

--- a/docs/supported-databases/mysql.rst
+++ b/docs/supported-databases/mysql.rst
@@ -6,9 +6,7 @@ Integration with `MySQL <https://www.mysql.com/>`_
 Installation
 ------------
 
-.. code-block:: bash
-
-   pip install pytest-databases[mysql]
+MySQL support is built-in and does not require any additional Python client libraries for basic service management. However, to connect to the database from your tests, you should install your preferred MySQL client (e.g., `mysql-connector-python`).
 
 Usage Example
 -------------
@@ -22,6 +20,7 @@ Usage Example
     pytest_plugins = ["pytest_databases.docker.mysql"]
 
     def test(mysql_service: MySQLService) -> None:
+        # Create your own connection using the service fixture attributes
         with mysql.connector.connect(
             host=mysql_service.host,
             port=mysql_service.port,
@@ -33,24 +32,21 @@ Usage Example
             resp = cursor.fetchone()
             assert resp is not None and resp[0] == 1
 
-    def test(mysql_connection: mysql.connector.MySQLConnection) -> None:
-        with mysql_connection.cursor() as cursor:
-            cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-            cursor.execute("select * from simple_table")
-            result = cursor.fetchall()
-            assert result is not None and result[0][0] == 1
-
 Available Fixtures
 ------------------
 
-* ``mysql_service``: A fixture that provides a MySQL service (latest version).
-* ``mysql_connection``: A fixture that provides a MySQL connection.
+* ``mysql_service``: A fixture that provides a MySQL service (8.4 LTS).
 
 The following version-specific fixtures are also available:
 
-* ``mysql_56_service``, ``mysql_56_connection``: MySQL 5.6
-* ``mysql_57_service``, ``mysql_57_connection``: MySQL 5.7
-* ``mysql_8_service``, ``mysql_8_connection``: MySQL 8.x
+* ``mysql_56_service``: MySQL 5.6
+* ``mysql_57_service``: MySQL 5.7
+* ``mysql_8_service``: MySQL 8.0
+* ``mysql_84_service``: MySQL 8.4 LTS
+* ``mysql_96_service``: MySQL 9.6 Innovation
+
+.. note::
+   The connection fixtures (e.g., ``mysql_connection``, ``mysql_84_connection``) are deprecated and will be removed in a future release. Users are encouraged to create their own connections as shown in the example above.
 
 Service API
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,8 @@ elasticsearch7 = ["elasticsearch7"]
 elasticsearch8 = ["elasticsearch8"]
 gizmosql = ["adbc-driver-flightsql", "pyarrow"]
 keydb = ["redis"]
-mariadb = ["mariadb"]
 mongodb = ["pymongo"]
 mssql = ["pymssql"]
-mysql = ["mysql-connector-python"]
 oracle = ["oracledb"]
 postgres = ["psycopg>=3"]
 redis = ["redis"]
@@ -127,6 +125,8 @@ test = [
   "pytest-click",
   "pytest-xdist",
   "pytest-sugar",
+  "mysql-connector-python",
+  "mariadb",
 ]
 
 ##################

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 import contextlib
-import traceback
+import os
+import warnings
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-import mariadb
 import pytest
 
 from pytest_databases.helpers import get_xdist_worker_num
 from pytest_databases.types import ServiceContainer, XdistIsolationLevel
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from pytest_databases._service import DockerService
 
 
@@ -31,38 +29,28 @@ def xdist_mariadb_isolation_level() -> XdistIsolationLevel:
 
 
 @contextlib.contextmanager
-def _provide_mysql_service(
+def _provide_mariadb_service(
     docker_service: DockerService,
     image: str,
     name: str,
     isolation_level: XdistIsolationLevel,
 ) -> Generator[MariaDBService, None, None]:
-    user = "app"
-    password = "super-secret"
-    root_password = "super-secret"
-    database = "db"
+    user = os.getenv("MARIADB_USER", "app")
+    password = os.getenv("MARIADB_PASSWORD", "super-secret")
+    root_password = os.getenv("MARIADB_ROOT_PASSWORD", "super-secret")
+    database = os.getenv("MARIADB_DATABASE", "db")
 
     def check(_service: ServiceContainer) -> bool:
-        try:
-            conn = mariadb.connect(
-                host=_service.host,
-                port=_service.port,
-                user=user,
-                database=database,
-                password=password,
-            )
-        except Exception:  # noqa: BLE001
-            traceback.print_exc()
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if not container:
             return False
 
-        try:
-            with conn.cursor() as cursor:
-                cursor.execute("select 1 as is_available")
-                resp = cursor.fetchone()
-                return resp is not None and resp[0] == 1
-        finally:
-            with contextlib.suppress(Exception):
-                conn.close()
+        # Attempt to run a simple SELECT 1 to ensure the server is fully ready
+        res = container.exec_run(
+            ["mariadb", f"--user=root", f"--password={root_password}", "-e", "SELECT 1"],
+        )
+        return res.exit_code == 0
 
     worker_num = get_xdist_worker_num()
     db_name = "pytest_databases"
@@ -86,15 +74,29 @@ def _provide_mysql_service(
             "MARIADB_ROOT_HOST": "%",
             "LANG": "C.UTF-8",
         },
-        timeout=60,
-        pause=0.5,
-        exec_after_start=(
-            f'mariadb --user=root --password={root_password} -e "CREATE DATABASE {db_name};'
-            f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
-            'FLUSH PRIVILEGES;"'
-        ),
+        timeout=120,
+        pause=1.0,
         transient=isolation_level == "server",
     ) as service:
+        # Final setup: ensure the worker-specific database exists and permissions are correct
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if container:
+            setup_sql = (
+                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
+                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
+                "FLUSH PRIVILEGES;"
+            )
+            # Retry setup a few times if it fails
+            for _ in range(5):
+                res = container.exec_run(
+                    ["mariadb", f"--user=root", f"--password={root_password}", "-e", setup_sql],
+                )
+                if res.exit_code == 0:
+                    break
+                import time
+                time.sleep(1)
+
         yield MariaDBService(
             db=db_name,
             host=service.host,
@@ -109,7 +111,7 @@ def mariadb_113_service(
     docker_service: DockerService,
     xdist_mariadb_isolation_level: XdistIsolationLevel,
 ) -> Generator[MariaDBService, None, None]:
-    with _provide_mysql_service(
+    with _provide_mariadb_service(
         docker_service=docker_service,
         image="mariadb:11.3",
         name="mariadb-11.3",
@@ -119,12 +121,58 @@ def mariadb_113_service(
 
 
 @pytest.fixture(autouse=False, scope="session")
-def mariadb_service(mariadb_113_service: MariaDBService) -> MariaDBService:
-    return mariadb_113_service
+def mariadb_114_service(
+    docker_service: DockerService,
+    xdist_mariadb_isolation_level: XdistIsolationLevel,
+) -> Generator[MariaDBService, None, None]:
+    with _provide_mariadb_service(
+        docker_service=docker_service,
+        image="mariadb:11.4",
+        name="mariadb-11.4",
+        isolation_level=xdist_mariadb_isolation_level,
+    ) as service:
+        yield service
 
 
 @pytest.fixture(autouse=False, scope="session")
-def mariadb_113_connection(mariadb_113_service: MariaDBService) -> Generator[mariadb.Connection, None, None]:
+def mariadb_122_service(
+    docker_service: DockerService,
+    xdist_mariadb_isolation_level: XdistIsolationLevel,
+) -> Generator[MariaDBService, None, None]:
+    with _provide_mariadb_service(
+        docker_service=docker_service,
+        image="mariadb:12.2",
+        name="mariadb-12.2",
+        isolation_level=xdist_mariadb_isolation_level,
+    ) as service:
+        yield service
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mariadb_service(mariadb_114_service: MariaDBService) -> MariaDBService:
+    return mariadb_114_service
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mariadb_113_connection(mariadb_113_service: MariaDBService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mariadb_113_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mariadb\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mariadb_connection(mariadb_113_service):\n"
+        "    with mariadb.connect(\n"
+        "        host=mariadb_113_service.host,\n"
+        "        port=mariadb_113_service.port,\n"
+        "        user=mariadb_113_service.user,\n"
+        "        database=mariadb_113_service.db,\n"
+        "        password=mariadb_113_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mariadb
     with mariadb.connect(
         host=mariadb_113_service.host,
         port=mariadb_113_service.port,
@@ -136,5 +184,65 @@ def mariadb_113_connection(mariadb_113_service: MariaDBService) -> Generator[mar
 
 
 @pytest.fixture(autouse=False, scope="session")
-def mariadb_connection(mariadb_113_connection: mariadb.Connection) -> mariadb.Connection:
-    return mariadb_113_connection
+def mariadb_114_connection(mariadb_114_service: MariaDBService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mariadb_114_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mariadb\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mariadb_connection(mariadb_114_service):\n"
+        "    with mariadb.connect(\n"
+        "        host=mariadb_114_service.host,\n"
+        "        port=mariadb_114_service.port,\n"
+        "        user=mariadb_114_service.user,\n"
+        "        database=mariadb_114_service.db,\n"
+        "        password=mariadb_114_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mariadb
+    with mariadb.connect(
+        host=mariadb_114_service.host,
+        port=mariadb_114_service.port,
+        user=mariadb_114_service.user,
+        database=mariadb_114_service.db,
+        password=mariadb_114_service.password,
+    ) as conn:
+        yield conn
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mariadb_122_connection(mariadb_122_service: MariaDBService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mariadb_122_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mariadb\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mariadb_connection(mariadb_122_service):\n"
+        "    with mariadb.connect(\n"
+        "        host=mariadb_122_service.host,\n"
+        "        port=mariadb_122_service.port,\n"
+        "        user=mariadb_122_service.user,\n"
+        "        database=mariadb_122_service.db,\n"
+        "        password=mariadb_122_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mariadb
+    with mariadb.connect(
+        host=mariadb_122_service.host,
+        port=mariadb_122_service.port,
+        user=mariadb_122_service.user,
+        database=mariadb_122_service.db,
+        password=mariadb_122_service.password,
+    ) as conn:
+        yield conn
+
+
+@pytest.fixture(autouse=False, scope="session")
+def mariadb_connection(mariadb_114_connection: Any) -> Any:
+    return mariadb_114_connection

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import os
+import time
 import warnings
-from collections.abc import Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +13,8 @@ from pytest_databases.helpers import get_xdist_worker_num
 from pytest_databases.types import ServiceContainer, XdistIsolationLevel
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_databases._service import DockerService
 
 
@@ -48,7 +50,7 @@ def _provide_mariadb_service(
 
         # Attempt to run a simple SELECT 1 to ensure the server is fully ready
         res = container.exec_run(
-            ["mariadb", f"--user=root", f"--password={root_password}", "-e", "SELECT 1"],
+            ["mariadb", "--user=root", f"--password={root_password}", "-e", "SELECT 1"],
         )
         return res.exit_code == 0
 
@@ -90,11 +92,10 @@ def _provide_mariadb_service(
             # Retry setup a few times if it fails
             for _ in range(5):
                 res = container.exec_run(
-                    ["mariadb", f"--user=root", f"--password={root_password}", "-e", setup_sql],
+                    ["mariadb", "--user=root", f"--password={root_password}", "-e", setup_sql],
                 )
                 if res.exit_code == 0:
                     break
-                import time
                 time.sleep(1)
 
         yield MariaDBService(
@@ -159,7 +160,7 @@ def mariadb_113_connection(mariadb_113_service: MariaDBService) -> Generator[Any
         "The 'mariadb_113_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mariadb\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mariadb_connection(mariadb_113_service):\n"
         "    with mariadb.connect(\n"
         "        host=mariadb_113_service.host,\n"
@@ -172,7 +173,7 @@ def mariadb_113_connection(mariadb_113_service: MariaDBService) -> Generator[Any
         DeprecationWarning,
         stacklevel=2,
     )
-    import mariadb
+    import mariadb  # noqa: PLC0415
     with mariadb.connect(
         host=mariadb_113_service.host,
         port=mariadb_113_service.port,
@@ -189,7 +190,7 @@ def mariadb_114_connection(mariadb_114_service: MariaDBService) -> Generator[Any
         "The 'mariadb_114_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mariadb\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mariadb_connection(mariadb_114_service):\n"
         "    with mariadb.connect(\n"
         "        host=mariadb_114_service.host,\n"
@@ -202,7 +203,7 @@ def mariadb_114_connection(mariadb_114_service: MariaDBService) -> Generator[Any
         DeprecationWarning,
         stacklevel=2,
     )
-    import mariadb
+    import mariadb  # noqa: PLC0415
     with mariadb.connect(
         host=mariadb_114_service.host,
         port=mariadb_114_service.port,
@@ -219,7 +220,7 @@ def mariadb_122_connection(mariadb_122_service: MariaDBService) -> Generator[Any
         "The 'mariadb_122_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mariadb\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mariadb_connection(mariadb_122_service):\n"
         "    with mariadb.connect(\n"
         "        host=mariadb_122_service.host,\n"
@@ -232,7 +233,7 @@ def mariadb_122_connection(mariadb_122_service: MariaDBService) -> Generator[Any
         DeprecationWarning,
         stacklevel=2,
     )
-    import mariadb
+    import mariadb  # noqa: PLC0415
     with mariadb.connect(
         host=mariadb_122_service.host,
         port=mariadb_122_service.port,

--- a/src/pytest_databases/docker/minio.py
+++ b/src/pytest_databases/docker/minio.py
@@ -115,14 +115,14 @@ def minio_service(
         except ImageNotFound:
             client.images.pull("minio/mc:latest")
 
-        command = [
+        command = " ".join([
             "sh",
             "-c",
             (
                 f"mc alias set local {endpoint_url} {minio_access_key} {minio_secret_key} && "
                 f"mc mb local/{minio_default_bucket_name}"
             ),
-        ]
+        ])
 
         with contextlib.suppress(Exception):
             client.containers.run(

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import contextlib
+import os
+import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-import mysql.connector
 import pytest
 
 from pytest_databases._service import DockerService, ServiceContainer
@@ -12,8 +13,6 @@ from pytest_databases.helpers import get_xdist_worker_num
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-
-    from mysql.connector.abstracts import MySQLConnectionAbstract
 
     from pytest_databases.types import XdistIsolationLevel
 
@@ -43,34 +42,22 @@ def _provide_mysql_service(
     isolation_level: XdistIsolationLevel,
     platform: str,
 ) -> Generator[MySQLService, None, None]:
-    user = "app"
-    password = "super-secret"
-    root_password = "super-secret"
-    database = "db"
+    user = os.getenv("MYSQL_USER", "app")
+    password = os.getenv("MYSQL_PASSWORD", "super-secret")
+    root_password = os.getenv("MYSQL_ROOT_PASSWORD", "super-secret")
+    database = os.getenv("MYSQL_DATABASE", "db")
 
     def check(_service: ServiceContainer) -> bool:
-        try:
-            conn = mysql.connector.connect(
-                host=_service.host,
-                port=_service.port,
-                user=user,
-                database=database,
-                password=password,
-            )
-        except (mysql.connector.errors.OperationalError, mysql.connector.errors.InterfaceError) as exc:
-            msg = getattr(exc, "msg", str(exc))
-            if "Lost connection" in msg:
-                return False
-            raise
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if not container:
+            return False
 
-        try:
-            with conn.cursor() as cursor:
-                cursor.execute("select 1 as is_available")
-                resp = cursor.fetchone()
-            return resp is not None and resp[0] == 1  # type: ignore
-        finally:
-            with contextlib.suppress(Exception):
-                conn.close()
+        # Attempt to run a simple SELECT 1 to ensure the server is fully ready
+        res = container.exec_run(
+            ["mysql", f"--user=root", f"--password={root_password}", "-e", "SELECT 1"],
+        )
+        return res.exit_code == 0
 
     worker_num = get_xdist_worker_num()
     db_name = "pytest_databases"
@@ -94,16 +81,31 @@ def _provide_mysql_service(
             "MYSQL_ROOT_HOST": "%",
             "LANG": "C.UTF-8",
         },
-        timeout=60,
-        pause=0.5,
-        exec_after_start=(
-            f'mysql --user=root --password={root_password} -e "CREATE DATABASE {db_name};'
-            f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
-            'FLUSH PRIVILEGES;"'
-        ),
+        timeout=120,
+        pause=1.0,
         transient=isolation_level == "server",
         platform=platform,
     ) as service:
+        # Final setup: ensure the worker-specific database exists and permissions are correct
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if container:
+            # Grant global privileges to the app user so they can create databases in tests if needed
+            setup_sql = (
+                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
+                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
+                "FLUSH PRIVILEGES;"
+            )
+            # Retry setup a few times if it fails
+            for _ in range(5):
+                res = container.exec_run(
+                    ["mysql", f"--user=root", f"--password={root_password}", "-e", setup_sql],
+                )
+                if res.exit_code == 0:
+                    break
+                import time
+                time.sleep(1)
+
         yield MySQLService(
             db=db_name,
             host=service.host,
@@ -114,8 +116,8 @@ def _provide_mysql_service(
 
 
 @pytest.fixture(scope="session")
-def mysql_service(mysql_8_service: MySQLService) -> MySQLService:
-    return mysql_8_service
+def mysql_service(mysql_84_service: MySQLService) -> MySQLService:
+    return mysql_84_service
 
 
 @pytest.fixture(scope="session")
@@ -167,7 +169,57 @@ def mysql_8_service(
 
 
 @pytest.fixture(scope="session")
-def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[MySQLConnectionAbstract, None, None]:
+def mysql_84_service(
+    docker_service: DockerService,
+    xdist_mysql_isolation_level: XdistIsolationLevel,
+    platform: str,
+) -> Generator[MySQLService, None, None]:
+    with _provide_mysql_service(
+        image="mysql:8.4",
+        name="mysql-8.4",
+        docker_service=docker_service,
+        isolation_level=xdist_mysql_isolation_level,
+        platform=platform,
+    ) as service:
+        yield service
+
+
+@pytest.fixture(scope="session")
+def mysql_96_service(
+    docker_service: DockerService,
+    xdist_mysql_isolation_level: XdistIsolationLevel,
+    platform: str,
+) -> Generator[MySQLService, None, None]:
+    with _provide_mysql_service(
+        image="mysql:9.6",
+        name="mysql-9.6",
+        docker_service=docker_service,
+        isolation_level=xdist_mysql_isolation_level,
+        platform=platform,
+    ) as service:
+        yield service
+
+
+@pytest.fixture(scope="session")
+def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mysql_56_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mysql.connector\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mysql_connection(mysql_56_service):\n"
+        "    with mysql.connector.connect(\n"
+        "        host=mysql_56_service.host,\n"
+        "        port=mysql_56_service.port,\n"
+        "        user=mysql_56_service.user,\n"
+        "        database=mysql_56_service.db,\n"
+        "        password=mysql_56_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mysql.connector
     with mysql.connector.connect(
         host=mysql_56_service.host,
         port=mysql_56_service.port,
@@ -175,11 +227,29 @@ def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[MySQLConnec
         database=mysql_56_service.db,
         password=mysql_56_service.password,
     ) as conn:
-        yield conn  # type: ignore
+        yield conn
 
 
 @pytest.fixture(scope="session")
-def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[MySQLConnectionAbstract, None, None]:
+def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mysql_57_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mysql.connector\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mysql_connection(mysql_57_service):\n"
+        "    with mysql.connector.connect(\n"
+        "        host=mysql_57_service.host,\n"
+        "        port=mysql_57_service.port,\n"
+        "        user=mysql_57_service.user,\n"
+        "        database=mysql_57_service.db,\n"
+        "        password=mysql_57_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mysql.connector
     with mysql.connector.connect(
         host=mysql_57_service.host,
         port=mysql_57_service.port,
@@ -187,16 +257,34 @@ def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[MySQLConnec
         database=mysql_57_service.db,
         password=mysql_57_service.password,
     ) as conn:
-        yield conn  # type: ignore
+        yield conn
 
 
 @pytest.fixture(scope="session")
-def mysql_connection(mysql_8_connection: MySQLConnectionAbstract) -> MySQLConnectionAbstract:
-    return mysql_8_connection
+def mysql_connection(mysql_84_connection: Any) -> Any:
+    return mysql_84_connection
 
 
 @pytest.fixture(scope="session")
-def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[MySQLConnectionAbstract, None, None]:
+def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mysql_8_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mysql.connector\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mysql_connection(mysql_8_service):\n"
+        "    with mysql.connector.connect(\n"
+        "        host=mysql_8_service.host,\n"
+        "        port=mysql_8_service.port,\n"
+        "        user=mysql_8_service.user,\n"
+        "        database=mysql_8_service.db,\n"
+        "        password=mysql_8_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mysql.connector
     with mysql.connector.connect(
         host=mysql_8_service.host,
         port=mysql_8_service.port,
@@ -204,4 +292,64 @@ def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[MySQLConnecti
         database=mysql_8_service.db,
         password=mysql_8_service.password,
     ) as conn:
-        yield conn  # type: ignore
+        yield conn
+
+
+@pytest.fixture(scope="session")
+def mysql_84_connection(mysql_84_service: MySQLService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mysql_84_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mysql.connector\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mysql_connection(mysql_84_service):\n"
+        "    with mysql.connector.connect(\n"
+        "        host=mysql_84_service.host,\n"
+        "        port=mysql_84_service.port,\n"
+        "        user=mysql_84_service.user,\n"
+        "        database=mysql_84_service.db,\n"
+        "        password=mysql_84_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mysql.connector
+    with mysql.connector.connect(
+        host=mysql_84_service.host,
+        port=mysql_84_service.port,
+        user=mysql_84_service.user,
+        database=mysql_84_service.db,
+        password=mysql_84_service.password,
+    ) as conn:
+        yield conn
+
+
+@pytest.fixture(scope="session")
+def mysql_96_connection(mysql_96_service: MySQLService) -> Generator[Any, None, None]:
+    warnings.warn(
+        "The 'mysql_96_connection' fixture is deprecated and will be removed in a future release. "
+        "To recreate this connection, you can use the following snippet:\n\n"
+        "import mysql.connector\n\n"
+        "@pytest.fixture(scope=\"session\")\n"
+        "def my_mysql_connection(mysql_96_service):\n"
+        "    with mysql.connector.connect(\n"
+        "        host=mysql_96_service.host,\n"
+        "        port=mysql_96_service.port,\n"
+        "        user=mysql_96_service.user,\n"
+        "        database=mysql_96_service.db,\n"
+        "        password=mysql_96_service.password,\n"
+        "    ) as conn:\n"
+        "        yield conn",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import mysql.connector
+    with mysql.connector.connect(
+        host=mysql_96_service.host,
+        port=mysql_96_service.port,
+        user=mysql_96_service.user,
+        database=mysql_96_service.db,
+        password=mysql_96_service.password,
+    ) as conn:
+        yield conn

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import time
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -55,7 +56,7 @@ def _provide_mysql_service(
 
         # Attempt to run a simple SELECT 1 to ensure the server is fully ready
         res = container.exec_run(
-            ["mysql", f"--user=root", f"--password={root_password}", "-e", "SELECT 1"],
+            ["mysql", "--user=root", f"--password={root_password}", "-e", "SELECT 1"],
         )
         return res.exit_code == 0
 
@@ -99,11 +100,10 @@ def _provide_mysql_service(
             # Retry setup a few times if it fails
             for _ in range(5):
                 res = container.exec_run(
-                    ["mysql", f"--user=root", f"--password={root_password}", "-e", setup_sql],
+                    ["mysql", "--user=root", f"--password={root_password}", "-e", setup_sql],
                 )
                 if res.exit_code == 0:
                     break
-                import time
                 time.sleep(1)
 
         yield MySQLService(
@@ -206,7 +206,7 @@ def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[Any, None, 
         "The 'mysql_56_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mysql.connector\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mysql_connection(mysql_56_service):\n"
         "    with mysql.connector.connect(\n"
         "        host=mysql_56_service.host,\n"
@@ -219,7 +219,7 @@ def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[Any, None, 
         DeprecationWarning,
         stacklevel=2,
     )
-    import mysql.connector
+    import mysql.connector  # noqa: PLC0415
     with mysql.connector.connect(
         host=mysql_56_service.host,
         port=mysql_56_service.port,
@@ -236,7 +236,7 @@ def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[Any, None, 
         "The 'mysql_57_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mysql.connector\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mysql_connection(mysql_57_service):\n"
         "    with mysql.connector.connect(\n"
         "        host=mysql_57_service.host,\n"
@@ -249,7 +249,7 @@ def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[Any, None, 
         DeprecationWarning,
         stacklevel=2,
     )
-    import mysql.connector
+    import mysql.connector  # noqa: PLC0415
     with mysql.connector.connect(
         host=mysql_57_service.host,
         port=mysql_57_service.port,
@@ -271,7 +271,7 @@ def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[Any, None, No
         "The 'mysql_8_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mysql.connector\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mysql_connection(mysql_8_service):\n"
         "    with mysql.connector.connect(\n"
         "        host=mysql_8_service.host,\n"
@@ -284,7 +284,7 @@ def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[Any, None, No
         DeprecationWarning,
         stacklevel=2,
     )
-    import mysql.connector
+    import mysql.connector  # noqa: PLC0415
     with mysql.connector.connect(
         host=mysql_8_service.host,
         port=mysql_8_service.port,
@@ -301,7 +301,7 @@ def mysql_84_connection(mysql_84_service: MySQLService) -> Generator[Any, None, 
         "The 'mysql_84_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mysql.connector\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mysql_connection(mysql_84_service):\n"
         "    with mysql.connector.connect(\n"
         "        host=mysql_84_service.host,\n"
@@ -314,7 +314,7 @@ def mysql_84_connection(mysql_84_service: MySQLService) -> Generator[Any, None, 
         DeprecationWarning,
         stacklevel=2,
     )
-    import mysql.connector
+    import mysql.connector  # noqa: PLC0415
     with mysql.connector.connect(
         host=mysql_84_service.host,
         port=mysql_84_service.port,
@@ -331,7 +331,7 @@ def mysql_96_connection(mysql_96_service: MySQLService) -> Generator[Any, None, 
         "The 'mysql_96_connection' fixture is deprecated and will be removed in a future release. "
         "To recreate this connection, you can use the following snippet:\n\n"
         "import mysql.connector\n\n"
-        "@pytest.fixture(scope=\"session\")\n"
+        '@pytest.fixture(scope="session")\n'
         "def my_mysql_connection(mysql_96_service):\n"
         "    with mysql.connector.connect(\n"
         "        host=mysql_96_service.host,\n"
@@ -344,7 +344,7 @@ def mysql_96_connection(mysql_96_service: MySQLService) -> Generator[Any, None, 
         DeprecationWarning,
         stacklevel=2,
     )
-    import mysql.connector
+    import mysql.connector  # noqa: PLC0415
     with mysql.connector.connect(
         host=mysql_96_service.host,
         port=mysql_96_service.port,

--- a/tests/test_rustfs_config.py
+++ b/tests/test_rustfs_config.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_rustfs_custom_bucket_env(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> None:
     pytester.makepyfile("""
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -3872,18 +3872,11 @@ keydb = [
     { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "redis", version = "7.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-mariadb = [
-    { name = "mariadb" },
-]
 mongodb = [
     { name = "pymongo" },
 ]
 mssql = [
     { name = "pymssql" },
-]
-mysql = [
-    { name = "mysql-connector-python", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -3915,8 +3908,11 @@ dev = [
     { name = "bump-my-version" },
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.13.5", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "mariadb" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "1.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "mysql-connector-python", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4025,6 +4021,9 @@ lint = [
 test = [
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.13.5", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "mariadb" },
+    { name = "mysql-connector-python", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cdist", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -4046,8 +4045,6 @@ requires-dist = [
     { name = "filelock" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'" },
     { name = "google-cloud-spanner", marker = "extra == 'spanner'" },
-    { name = "mariadb", marker = "extra == 'mariadb'" },
-    { name = "mysql-connector-python", marker = "extra == 'mysql'" },
     { name = "oracledb", marker = "extra == 'oracle'" },
     { name = "psycopg", marker = "extra == 'cockroachdb'" },
     { name = "psycopg", marker = "extra == 'postgres'", specifier = ">=3" },
@@ -4061,7 +4058,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'" },
     { name = "valkey", marker = "extra == 'valkey'" },
 ]
-provides-extras = ["azure-storage", "bigquery", "cockroachdb", "dragonfly", "elasticsearch7", "elasticsearch8", "gizmosql", "keydb", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres", "redis", "spanner", "valkey", "yugabyte"]
+provides-extras = ["azure-storage", "bigquery", "cockroachdb", "dragonfly", "elasticsearch7", "elasticsearch8", "gizmosql", "keydb", "mongodb", "mssql", "oracle", "postgres", "redis", "spanner", "valkey", "yugabyte"]
 
 [package.metadata.requires-dev]
 build = [{ name = "bump-my-version" }]
@@ -4069,7 +4066,9 @@ dev = [
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "bump-my-version" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
+    { name = "mariadb" },
     { name = "mypy" },
+    { name = "mysql-connector-python" },
     { name = "myst-parser" },
     { name = "pre-commit" },
     { name = "psycopg", extras = ["binary", "pool"] },
@@ -4144,6 +4143,8 @@ lint = [
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
+    { name = "mariadb" },
+    { name = "mysql-connector-python" },
     { name = "pytest" },
     { name = "pytest-cdist", specifier = ">=0.2" },
     { name = "pytest-click" },


### PR DESCRIPTION
This PR migrates MySQL and MariaDB service fixtures to a 'oneshot' approach using `docker exec` with native clients for health checks and setup. This removes the core dependency on Python client libraries (`mysql-connector-python` and `mariadb`).

Key changes:
- Refactored MySQL and MariaDB health checks and setup to use native clients inside containers.
- Added support for MySQL 8.4 LTS, 9.6 Innovation, MariaDB 11.4 LTS, and 12.2 Rolling.
- Moved client libraries to the `test` dependency group.
- Deprecated existing connection fixtures with informative warnings and migration snippets.
- Updated documentation for both databases.