### PR TITLE
feat(dolt): add dolt database service support

### DIFF
--- a/docs/supported-databases/dolt.rst
+++ b/docs/supported-databases/dolt.rst
@@ -1,0 +1,59 @@
+Dolt
+====
+
+Integration with `Dolt <https://www.dolthub.com/>`_
+
+Dolt is a MySQL-compatible database that provides Git-like versioning for your data.
+
+Installation
+------------
+
+Dolt support is built-in and does not require any additional Python client libraries for basic service management. Since Dolt is MySQL-compatible, you can connect to the database from your tests using your preferred MySQL client (e.g., ``mysql-connector-python``).
+
+Usage Example
+-------------
+
+.. code-block:: python
+
+    import pytest
+    import mysql.connector
+    from pytest_databases.docker.dolt import DoltService
+
+    pytest_plugins = ["pytest_databases.docker.dolt"]
+
+    def test(dolt_service: DoltService) -> None:
+        # Create your own connection using the service fixture attributes
+        with mysql.connector.connect(
+            host=dolt_service.host,
+            port=dolt_service.port,
+            user=dolt_service.user,
+            database=dolt_service.db,
+            password=dolt_service.password,
+        ) as conn, conn.cursor() as cursor:
+            cursor.execute("select 1 as is_available")
+            resp = cursor.fetchone()
+            assert resp is not None and resp[0] == 1
+
+Available Fixtures
+------------------
+
+* ``dolt_service``: A fixture that provides a Dolt service (latest).
+
+Isolation Level
+---------------
+
+By default, the ``dolt_service`` fixture uses ``database`` isolation, where each worker gets its own database on a shared server. You can change this to ``server`` isolation by overriding the ``xdist_dolt_isolation_level`` fixture.
+
+.. code-block:: python
+
+    @pytest.fixture(scope="session")
+    def xdist_dolt_isolation_level():
+        return "server"
+
+Service API
+-----------
+
+.. automodule:: pytest_databases.docker.dolt
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/supported-databases/index.rst
+++ b/docs/supported-databases/index.rst
@@ -9,6 +9,7 @@ This section provides detailed information on the supported databases, including
    postgres
    mysql
    mariadb
+   dolt
    oracle
    sqlserver
    spanner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ keywords = [
   "alloydb",
   "alloydbomni",
   "cockroachdb",
+  "doltdb",
   "redis",
   "elasticsearch",
   "azure",

--- a/src/pytest_databases/docker/dolt.py
+++ b/src/pytest_databases/docker/dolt.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer, XdistIsolationLevel
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_databases._service import DockerService
+
+
+@dataclass
+class DoltService(ServiceContainer):
+    db: str
+    user: str
+    password: str
+
+
+@pytest.fixture(scope="session")
+def xdist_dolt_isolation_level() -> XdistIsolationLevel:
+    return "database"
+
+
+@pytest.fixture(scope="session")
+def platform() -> str:
+    return "linux/x86_64"
+
+
+@contextlib.contextmanager
+def _provide_dolt_service(
+    docker_service: DockerService,
+    image: str,
+    name: str,
+    isolation_level: XdistIsolationLevel,
+    platform: str,
+) -> Generator[DoltService, None, None]:
+    user = os.getenv("DOLT_USER", "app")
+    password = os.getenv("DOLT_PASSWORD", "super-secret")
+    root_password = os.getenv("DOLT_ROOT_PASSWORD", "super-secret")
+    database = os.getenv("DOLT_DATABASE", "db")
+
+    def check(_service: ServiceContainer) -> bool:
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if not container:
+            return False
+
+        # Attempt to run a simple SELECT 1 to ensure the server is fully ready
+        res = container.exec_run(
+            ["dolt", "sql", "-q", "SELECT 1"],
+        )
+        return res.exit_code == 0
+
+    worker_num = get_xdist_worker_num()
+    db_name = "pytest_databases"
+    if worker_num is not None:
+        suffix = f"_{worker_num}"
+        if isolation_level == "server":
+            name += suffix
+        else:
+            db_name += suffix
+
+    with docker_service.run(
+        image=image,
+        check=check,
+        container_port=3306,
+        name=name,
+        env={
+            "DOLT_ROOT_PASSWORD": root_password,
+            "DOLT_ROOT_HOST": "%",
+            "DOLT_PASSWORD": password,
+            "DOLT_USER": user,
+            "DOLT_DATABASE": database,
+        },
+        timeout=120,
+        pause=1.0,
+        transient=isolation_level == "server",
+        platform=platform,
+    ) as service:
+        # Final setup: ensure the worker-specific database exists and permissions are correct
+        container_name = f"pytest_databases_{name}"
+        container = docker_service._get_container(container_name)
+        if container:
+            # Dolt SQL setup for database and user permissions
+            # We grant global privileges to the app user so they can create databases in tests if needed,
+            # matching the MySQL/MariaDB pattern.
+            setup_sql = (
+                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
+                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
+                "FLUSH PRIVILEGES;"
+            )
+            # Retry setup a few times if it fails
+            for _ in range(5):
+                res = container.exec_run(
+                    ["dolt", "sql", "-q", setup_sql],
+                )
+                if res.exit_code == 0:
+                    break
+                time.sleep(1)
+
+        yield DoltService(
+            db=db_name,
+            host=service.host,
+            port=service.port,
+            user=user,
+            password=password,
+        )
+
+
+@pytest.fixture(scope="session")
+def dolt_service(
+    docker_service: DockerService,
+    xdist_dolt_isolation_level: XdistIsolationLevel,
+    platform: str,
+) -> Generator[DoltService, None, None]:
+    with _provide_dolt_service(
+        image="dolthub/dolt-sql-server:latest",
+        name="dolt",
+        docker_service=docker_service,
+        isolation_level=xdist_dolt_isolation_level,
+        platform=platform,
+    ) as service:
+        yield service

--- a/tests/test_dolt.py
+++ b/tests/test_dolt.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "service_fixture",
+    [
+        "dolt_service",
+    ],
+)
+def test_service_fixture(pytester: pytest.Pytester, service_fixture: str) -> None:
+    pytester.makepyfile(f"""
+    import mysql.connector
+    pytest_plugins = ["pytest_databases.docker.dolt"]
+
+    def test({service_fixture}):
+        with mysql.connector.connect(
+            host={service_fixture}.host,
+            port={service_fixture}.port,
+            user={service_fixture}.user,
+            database={service_fixture}.db,
+            password={service_fixture}.password,
+        ) as conn, conn.cursor() as cursor:
+            cursor.execute("select 1 as is_available")
+            resp = cursor.fetchone()
+        assert resp is not None and resp[0] == 1
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_xdist_isolate_database(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import mysql.connector
+    import pytest
+    pytest_plugins = ["pytest_databases.docker.dolt"]
+
+    @pytest.fixture
+    def dolt_conn(dolt_service):
+        with mysql.connector.connect(
+            host=dolt_service.host,
+            port=dolt_service.port,
+            user=dolt_service.user,
+            database=dolt_service.db,
+            password=dolt_service.password,
+        ) as conn:
+            yield conn
+
+    def test_1(dolt_conn):
+        with dolt_conn.cursor() as cursor:
+            cursor.execute("CREATE TABLE simple_table as SELECT 1 as the_value;")
+
+    def test_2(dolt_conn):
+        with dolt_conn.cursor() as cursor:
+            cursor.execute("CREATE TABLE simple_table as SELECT 1 as the_value;")
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")
+    result.assert_outcomes(passed=2)
+
+
+def test_xdist_isolate_server(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import mysql.connector
+    import pytest
+    pytest_plugins = ["pytest_databases.docker.dolt"]
+
+    @pytest.fixture(scope="session")
+    def xdist_dolt_isolation_level():
+        return "server"
+
+    @pytest.fixture
+    def dolt_conn(dolt_service):
+        with mysql.connector.connect(
+            host=dolt_service.host,
+            port=dolt_service.port,
+            user=dolt_service.user,
+            database=dolt_service.db,
+            password=dolt_service.password,
+        ) as conn:
+            yield conn
+
+    def test_1(dolt_conn):
+        with dolt_conn.cursor() as cursor:
+            cursor.execute("CREATE DATABASE db_test")
+
+    def test_2(dolt_conn):
+        with dolt_conn.cursor() as cursor:
+            cursor.execute("CREATE DATABASE db_test")
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Description
This PR adds first-class support for **Dolt**, a MySQL-compatible database with Git-like versioning.

## Key Changes
- **Clientless Core**: Implemented `src/pytest_databases/docker/dolt.py` with 'oneshot' health checks via `docker exec`. No new Python client dependencies added to `src/`.
- **Xdist Support**: Fully supports `database` and `server` isolation levels for parallel test execution.
- **Fixtures**: Added `dolt_service` and `xdist_dolt_isolation_level` fixtures.
- **Testing**: Comprehensive tests in `tests/test_dolt.py` verifying service availability and isolation.
- **Documentation**: Added `docs/supported-databases/dolt.rst` and updated the index.
- **Metadata**: Updated `pyproject.toml` keywords.

## Verification
Ran `uv run pytest tests/test_dolt.py tests/test_mysql.py tests/test_mariadb.py` with all tests passing (16 passed).