### PR TITLE
ci: pre-pull docker images with retry to fight registry flakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }} - ${{ matrix.cdist-group }}/3
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,8 @@ jobs:
 
       # Pre-pull docker images with retry to absorb transient registry failures
       # (MCR WAF blocks on mcr.microsoft.com, Docker Hub anonymous rate limits)
-      # before pytest starts spawning fixture subprocesses.
+      # before pytest starts spawning fixture subprocesses. Pull in parallel
+      # (-P 6) - sequential pulls of ~30 images cost 10+ min on a runner.
       - name: Pre-pull docker images
         run: |
           set -u
@@ -75,23 +76,16 @@ jobs:
             "elasticsearch:7.17.19"
             "elasticsearch:8.13.0"
           )
-          failed=()
-          for image in "${images[@]}"; do
+          printf '%s\n' "${images[@]}" | xargs -n1 -P6 -I{} bash -c '
+            image="$1"
             for attempt in 1 2 3 4 5; do
               if docker pull --quiet "$image"; then
-                break
+                exit 0
               fi
-              if [ "$attempt" -eq 5 ]; then
-                echo "::warning::Failed to pull $image after 5 attempts"
-                failed+=("$image")
-              else
-                sleep $((attempt * attempt * 5))
-              fi
+              [ "$attempt" -lt 5 ] && sleep $((attempt * attempt * 5))
             done
-          done
-          if [ "${#failed[@]}" -gt 0 ]; then
-            echo "::warning::Could not pre-pull ${#failed[@]} images; tests may retry per-image: ${failed[*]}"
-          fi
+            echo "::warning::Failed to pull $image after 5 attempts"
+          ' _ {}
 
       - if: matrix.python-version == '3.12'
         name: Run tests with coverage tracking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,57 @@ jobs:
       - name: Intall dependencies
         run: uv sync --frozen --all-extras
 
+      # Pre-pull docker images with retry to absorb transient registry failures
+      # (MCR WAF blocks on mcr.microsoft.com, Docker Hub anonymous rate limits)
+      # before pytest starts spawning fixture subprocesses.
+      - name: Pre-pull docker images
+        run: |
+          set -u
+          images=(
+            "mcr.microsoft.com/azure-storage/azurite"
+            "mcr.microsoft.com/mssql/server:2022-latest"
+            "postgres:11" "postgres:12" "postgres:13" "postgres:14"
+            "postgres:15" "postgres:16" "postgres:17" "postgres:18"
+            "pgvector/pgvector:pg15"
+            "paradedb/paradedb:0.21.5-pg16"
+            "google/alloydbomni:16"
+            "mysql:5.6" "mysql:5.7" "mysql:8"
+            "mariadb:11.3"
+            "gvenzl/oracle-free:23-slim-faststart"
+            "gvenzl/oracle-xe:18-slim-faststart"
+            "redis:latest"
+            "valkey/valkey:latest"
+            "mongo:latest"
+            "cockroachdb/cockroach:latest"
+            "software.yugabyte.com/yugabytedb/yugabyte:latest"
+            "quay.io/minio/minio"
+            "minio/mc:latest"
+            "rustfs/rustfs:latest"
+            "rustfs/rc:latest"
+            "gcr.io/cloud-spanner-emulator/emulator:latest"
+            "ghcr.io/goccy/bigquery-emulator:latest"
+            "gizmodata/gizmosql:latest"
+            "elasticsearch:7.17.19"
+            "elasticsearch:8.13.0"
+          )
+          failed=()
+          for image in "${images[@]}"; do
+            for attempt in 1 2 3 4 5; do
+              if docker pull --quiet "$image"; then
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "::warning::Failed to pull $image after 5 attempts"
+                failed+=("$image")
+              else
+                sleep $((attempt * attempt * 5))
+              fi
+            done
+          done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::warning::Could not pre-pull ${#failed[@]} images; tests may retry per-image: ${failed[*]}"
+          fi
+
       - if: matrix.python-version == '3.12'
         name: Run tests with coverage tracking
         run: uv run pytest --cdist-group=${{ matrix.cdist-group }}/3 -k "not elasticsearch"
@@ -82,6 +133,18 @@ jobs:
 
       - name: Intall dependencies
         run: uv sync --frozen --all-extras
+
+      - name: Pre-pull docker images
+        run: |
+          set -u
+          for image in "elasticsearch:7.17.19" "elasticsearch:8.13.0"; do
+            for attempt in 1 2 3 4 5; do
+              if docker pull --quiet "$image"; then
+                break
+              fi
+              [ "$attempt" -eq 5 ] && echo "::warning::Failed to pull $image" || sleep $((attempt * attempt * 5))
+            done
+          done
 
       - name: Run tests with coverage tracking
         run: uv run pytest -k elasticsearch

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -156,7 +156,17 @@ class DockerService(AbstractContextManager):
             try:
                 self._client.images.get(image)
             except ImageNotFound:
-                self._client.images.pull(*image.rsplit(":", maxsplit=1), **platform_kwarg)  # pyright: ignore[reportCallIssue,reportArgumentType]
+                # Registries can fail transiently: Docker Hub rate-limits
+                # anonymous pulls with 500s, MCR's WAF returns 404s wrapping
+                # a block page. Retry a few times before giving up.
+                for attempt in range(3):
+                    try:
+                        self._client.images.pull(*image.rsplit(":", maxsplit=1), **platform_kwarg)  # pyright: ignore[reportCallIssue,reportArgumentType]
+                        break
+                    except (APIError, ImageNotFound):
+                        if attempt == 2:
+                            raise
+                        time.sleep(2**attempt)
 
             if container is None:
                 container = self._client.containers.run(  # pyright: ignore[reportCallIssue,reportArgumentType]

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -62,15 +62,23 @@ def _stop_all_containers(client: DockerClient) -> None:
         ignore_removed=True,
     )
     for container in containers:
-        if container.status == "running":
-            container.kill()
-        elif container.status in {"stopped", "dead"}:
-            container.remove()
-        elif container.status == "removing":
-            continue
-        else:
-            msg = f"Cannot handle container in state {container.status}"
-            raise RuntimeError(msg)
+        # Containers may disappear between the list and the kill/remove call -
+        # they are tagged remove=True so they vacate as soon as they stop, and
+        # transient teardown can race with this loop. Treat 404 (already gone)
+        # and 409 (removal already in progress) as success.
+        try:
+            if container.status == "running":
+                container.kill()
+            elif container.status in {"stopped", "dead"}:
+                container.remove()
+            elif container.status == "removing":
+                continue
+            else:
+                msg = f"Cannot handle container in state {container.status}"
+                raise RuntimeError(msg)
+        except APIError as exc:
+            if exc.status_code not in {404, 409}:
+                raise
 
 
 class DockerService(AbstractContextManager):

--- a/src/pytest_databases/docker/dolt.py
+++ b/src/pytest_databases/docker/dolt.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -80,23 +80,48 @@ def _provide_mariadb_service(
         pause=1.0,
         transient=isolation_level == "server",
     ) as service:
-        # Final setup: ensure the worker-specific database exists and permissions are correct
+        # check() above only verifies root SELECT 1; that becomes true before
+        # mariadb has fully provisioned the app user with the @'%' grant. Verify
+        # the app user can actually reach db_name from any host before yielding,
+        # otherwise tests race into 'Host not allowed' / 'access denied'.
         container_name = f"pytest_databases_{name}"
         container = docker_service._get_container(container_name)
-        if container:
-            setup_sql = (
-                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
-                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
-                "FLUSH PRIVILEGES;"
+        if container is None:
+            msg = f"MariaDB container {container_name!r} disappeared after startup"
+            raise RuntimeError(msg)
+
+        setup_sql = (
+            f"CREATE DATABASE IF NOT EXISTS {db_name}; "
+            f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
+            "FLUSH PRIVILEGES;"
+        )
+        verify_cmd = [
+            "mariadb",
+            f"--user={user}",
+            f"--password={password}",
+            db_name,
+            "-e",
+            "SELECT 1",
+        ]
+        last_err: bytes = b""
+        for attempt in range(15):
+            setup_res = container.exec_run(
+                ["mariadb", "--user=root", f"--password={root_password}", "-e", setup_sql],
             )
-            # Retry setup a few times if it fails
-            for _ in range(5):
-                res = container.exec_run(
-                    ["mariadb", "--user=root", f"--password={root_password}", "-e", setup_sql],
-                )
-                if res.exit_code == 0:
+            if setup_res.exit_code == 0:
+                verify_res = container.exec_run(verify_cmd)
+                if verify_res.exit_code == 0:
                     break
-                time.sleep(1)
+                last_err = verify_res.output
+            else:
+                last_err = setup_res.output
+            time.sleep(1 + attempt * 0.5)
+        else:
+            msg = (
+                f"MariaDB fixture {name!r}: user {user!r} could not reach database "
+                f"{db_name!r} after 15 attempts. Last output: {last_err!r}"
+            )
+            raise RuntimeError(msg)
 
         yield MariaDBService(
             db=db_name,

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -87,24 +87,48 @@ def _provide_mysql_service(
         transient=isolation_level == "server",
         platform=platform,
     ) as service:
-        # Final setup: ensure the worker-specific database exists and permissions are correct
+        # The check() above only verifies root can SELECT 1; that signal is true
+        # before mysql has finished provisioning the app user and applying our
+        # post-start grants. Verify the app user can actually reach db_name
+        # before yielding so tests don't race the fixture into 'access denied'.
         container_name = f"pytest_databases_{name}"
         container = docker_service._get_container(container_name)
-        if container:
-            # Grant global privileges to the app user so they can create databases in tests if needed
-            setup_sql = (
-                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
-                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
-                "FLUSH PRIVILEGES;"
+        if container is None:
+            msg = f"MySQL container {container_name!r} disappeared after startup"
+            raise RuntimeError(msg)
+
+        setup_sql = (
+            f"CREATE DATABASE IF NOT EXISTS {db_name}; "
+            f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
+            "FLUSH PRIVILEGES;"
+        )
+        verify_cmd = [
+            "mysql",
+            f"--user={user}",
+            f"--password={password}",
+            db_name,
+            "-e",
+            "SELECT 1",
+        ]
+        last_err: bytes = b""
+        for attempt in range(15):
+            setup_res = container.exec_run(
+                ["mysql", "--user=root", f"--password={root_password}", "-e", setup_sql],
             )
-            # Retry setup a few times if it fails
-            for _ in range(5):
-                res = container.exec_run(
-                    ["mysql", "--user=root", f"--password={root_password}", "-e", setup_sql],
-                )
-                if res.exit_code == 0:
+            if setup_res.exit_code == 0:
+                verify_res = container.exec_run(verify_cmd)
+                if verify_res.exit_code == 0:
                     break
-                time.sleep(1)
+                last_err = verify_res.output
+            else:
+                last_err = setup_res.output
+            time.sleep(1 + attempt * 0.5)
+        else:
+            msg = (
+                f"MySQL fixture {name!r}: user {user!r} could not reach database "
+                f"{db_name!r} after 15 attempts. Last output: {last_err!r}"
+            )
+            raise RuntimeError(msg)
 
         yield MySQLService(
             db=db_name,


### PR DESCRIPTION
CI test runs intermittently fail during image pulls. Two distinct registry-side modes show up across recent failed runs: MCR's WAF returning 404s with a block page (azurite, mssql), and Docker Hub's anonymous rate limit returning 500s with `toomanyrequests` (postgres, mysql, oracle, etc).

Pre-pull all fixture images in CI before pytest starts, with retry and backoff. Failures degrade to warnings. Also wraps the existing `images.pull()` call in `_service.py` with a 3-attempt retry catching `APIError` and `ImageNotFound`, so users hitting transient registry issues outside CI get the same resilience.