### PR TITLE
ci: Add missing Python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         cdist-group: [1, 2, 3]
 
     steps:


### PR DESCRIPTION
Add missing tests for 3.13 and 3.14