### PR TITLE
feat: move MySQL to clientless validation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,9 @@ autodoc_default_options = {
     "undoc-members": True,
     "exclude-members": "__weakref__",
 }
+autodoc_type_aliases = {
+    "Container": "docker.models.containers.Container",
+}
 
 # Mock imports for modules not needed during doc generation
 autodoc_mock_imports = ["OpenSSL"]

--- a/docs/supported-databases/mysql.rst
+++ b/docs/supported-databases/mysql.rst
@@ -6,7 +6,8 @@ Integration with `MySQL <https://www.mysql.com/>`_
 Installation
 ------------
 
-MySQL support is built-in and does not require any additional Python client libraries for basic service management. However, to connect to the database from your tests, you should install your preferred MySQL client (e.g., `mysql-connector-python`).
+The fixture provides a running MySQL service and validates availability with the container's bundled tools. Use the
+service attributes with the MySQL client, ORM, or application configuration you normally use.
 
 Usage Example
 -------------
@@ -20,7 +21,6 @@ Usage Example
     pytest_plugins = ["pytest_databases.docker.mysql"]
 
     def test(mysql_service: MySQLService) -> None:
-        # Create your own connection using the service fixture attributes
         with mysql.connector.connect(
             host=mysql_service.host,
             port=mysql_service.port,
@@ -36,6 +36,10 @@ Available Fixtures
 ------------------
 
 * ``mysql_service``: A fixture that provides a MySQL service (8.4 LTS).
+* ``mysql_user``: The application user configured in the container.
+* ``mysql_password``: The application user password configured in the container.
+* ``mysql_root_password``: The root password configured in the container.
+* ``mysql_database``: The initial database configured in the container.
 
 The following version-specific fixtures are also available:
 
@@ -44,9 +48,6 @@ The following version-specific fixtures are also available:
 * ``mysql_8_service``: MySQL 8.0
 * ``mysql_84_service``: MySQL 8.4 LTS
 * ``mysql_96_service``: MySQL 9.6 Innovation
-
-.. note::
-   The connection fixtures (e.g., ``mysql_connection``, ``mysql_84_connection``) are deprecated and will be removed in a future release. Users are encouraged to create their own connections as shown in the example above.
 
 Service API
 -----------

--- a/docs/supported-databases/yugabyte.rst
+++ b/docs/supported-databases/yugabyte.rst
@@ -10,6 +10,9 @@ Installation
 
    pip install pytest-databases[yugabyte]
 
+The fixture provides a running Yugabyte service and validates availability with Yugabyte's bundled tools. Use the
+service attributes with the PostgreSQL-compatible client, ORM, or application configuration you normally use.
+
 Usage Example
 -------------
 
@@ -23,26 +26,24 @@ Usage Example
 
     @pytest.fixture(scope="session")
     def yugabyte_uri(yugabyte_service: YugabyteService) -> str:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        return f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}"
+        return (
+            f"postgresql://{yugabyte_service.user}:{yugabyte_service.password}"
+            f"@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?sslmode=disable"
+        )
 
     def test_yugabyte_service(yugabyte_uri: str) -> None:
         with psycopg.connect(yugabyte_uri) as conn:
             db_open = conn.execute("SELECT 1").fetchone()
             assert db_open is not None and db_open[0] == 1
 
-    def test_yugabyte_connection(yugabyte_connection: psycopg.Connection) -> None:
-        yugabyte_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-        result = yugabyte_connection.execute("select * from simple_table").fetchone()
-        assert result is not None and result[0] == 1
-
 Available Fixtures
 ------------------
 
 * ``yugabyte_image``: The Docker image to use for Yugabyte DB.
+* ``yugabyte_user``: The Yugabyte user exposed on ``yugabyte_service``.
+* ``yugabyte_password``: The Yugabyte password exposed on ``yugabyte_service``.
+* ``yugabyte_database``: The database created for ``yugabyte_service``.
 * ``yugabyte_service``: A fixture that provides a Yugabyte DB service.
-* ``yugabyte_connection``: A fixture that provides a Yugabyte DB connection.
-* ``yugabyte_driver_opts``: A fixture that provides driver options for Yugabyte DB.
 
 Service API
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ keydb = ["redis"]
 mariadb = []
 mongodb = ["pymongo"]
 mssql = ["pymssql"]
+mysql = []
 oracle = ["oracledb"]
 postgres = ["psycopg>=3"]
 redis = ["redis"]
@@ -127,14 +128,6 @@ test = [
   "pytest-click",
   "pytest-xdist",
   "pytest-sugar",
-  # mysql-connector-python's wheel coverage degrades unpredictably each release:
-  #   3.9:    9.4.x is the last release with cp39 wheels
-  #   3.10+:  9.6.x is the latest release with full Linux/macOS/Windows coverage
-  #           (9.7.0 dropped Linux/Windows for cp311 and dropped cp312/cp313 entirely)
-  # Lower bounds force uv to fork the resolution per-interpreter - without them
-  # a single 9.4.0 satisfies every marker and gets locked universally.
-  "mysql-connector-python<9.5; python_version < '3.10'",
-  "mysql-connector-python>=9.6,<9.7; python_version >= '3.10'",
 ]
 
 ##################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ postgres = ["psycopg>=3"]
 redis = ["redis"]
 spanner = ["google-cloud-spanner"]
 valkey = ["valkey"]
-yugabyte = ["psycopg2-yugabytedb"]
+yugabyte = []
 
 [dependency-groups]
 build = ["bump-my-version"]
@@ -104,7 +104,7 @@ doc = [
   "sphinx-autodoc-typehints",
   "sphinx-rtd-theme",
 ]
-extra = ["psycopg2-binary", "psycopg[binary,pool]", "psycopg2-yugabytedb-binary"]
+extra = ["psycopg[binary,pool]"]
 lint = [
   "mypy",
   "ruff",

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import contextlib
 import os
 import time
-import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,9 +12,15 @@ from pytest_databases._service import DockerService, ServiceContainer
 from pytest_databases.helpers import get_xdist_worker_num
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterator
 
     from pytest_databases.types import XdistIsolationLevel
+
+
+def _output_to_bytes(output: bytes | Iterator[bytes]) -> bytes:
+    if isinstance(output, bytes):
+        return output
+    return b"".join(output)
 
 
 @dataclass
@@ -35,6 +40,26 @@ def platform() -> str:
     return "linux/x86_64"
 
 
+@pytest.fixture(scope="session")
+def mysql_user() -> str:
+    return os.getenv("MYSQL_USER", "app")
+
+
+@pytest.fixture(scope="session")
+def mysql_password() -> str:
+    return os.getenv("MYSQL_PASSWORD", "super-secret")
+
+
+@pytest.fixture(scope="session")
+def mysql_root_password() -> str:
+    return os.getenv("MYSQL_ROOT_PASSWORD", "super-secret")
+
+
+@pytest.fixture(scope="session")
+def mysql_database() -> str:
+    return os.getenv("MYSQL_DATABASE", "db")
+
+
 @contextlib.contextmanager
 def _provide_mysql_service(
     docker_service: DockerService,
@@ -42,12 +67,11 @@ def _provide_mysql_service(
     name: str,
     isolation_level: XdistIsolationLevel,
     platform: str,
+    user: str,
+    password: str,
+    root_password: str,
+    database: str,
 ) -> Generator[MySQLService, None, None]:
-    user = os.getenv("MYSQL_USER", "app")
-    password = os.getenv("MYSQL_PASSWORD", "super-secret")
-    root_password = os.getenv("MYSQL_ROOT_PASSWORD", "super-secret")
-    database = os.getenv("MYSQL_DATABASE", "db")
-
     def check(_service: ServiceContainer) -> bool:
         container_name = f"pytest_databases_{name}"
         container = docker_service._get_container(container_name)
@@ -119,9 +143,9 @@ def _provide_mysql_service(
                 verify_res = container.exec_run(verify_cmd)
                 if verify_res.exit_code == 0:
                     break
-                last_err = verify_res.output
+                last_err = _output_to_bytes(verify_res.output)
             else:
-                last_err = setup_res.output
+                last_err = _output_to_bytes(setup_res.output)
             time.sleep(1 + attempt * 0.5)
         else:
             msg = (
@@ -150,6 +174,10 @@ def mysql_56_service(
     docker_service: DockerService,
     xdist_mysql_isolation_level: XdistIsolationLevel,
     platform: str,
+    mysql_user: str,
+    mysql_password: str,
+    mysql_root_password: str,
+    mysql_database: str,
 ) -> Generator[MySQLService, None, None]:
     with _provide_mysql_service(
         image="mysql:5.6",
@@ -157,6 +185,10 @@ def mysql_56_service(
         docker_service=docker_service,
         isolation_level=xdist_mysql_isolation_level,
         platform=platform,
+        user=mysql_user,
+        password=mysql_password,
+        root_password=mysql_root_password,
+        database=mysql_database,
     ) as service:
         yield service
 
@@ -166,6 +198,10 @@ def mysql_57_service(
     docker_service: DockerService,
     xdist_mysql_isolation_level: XdistIsolationLevel,
     platform: str,
+    mysql_user: str,
+    mysql_password: str,
+    mysql_root_password: str,
+    mysql_database: str,
 ) -> Generator[MySQLService, None, None]:
     with _provide_mysql_service(
         image="mysql:5.7",
@@ -173,6 +209,10 @@ def mysql_57_service(
         docker_service=docker_service,
         isolation_level=xdist_mysql_isolation_level,
         platform=platform,
+        user=mysql_user,
+        password=mysql_password,
+        root_password=mysql_root_password,
+        database=mysql_database,
     ) as service:
         yield service
 
@@ -182,6 +222,10 @@ def mysql_8_service(
     docker_service: DockerService,
     xdist_mysql_isolation_level: XdistIsolationLevel,
     platform: str,
+    mysql_user: str,
+    mysql_password: str,
+    mysql_root_password: str,
+    mysql_database: str,
 ) -> Generator[MySQLService, None, None]:
     with _provide_mysql_service(
         image="mysql:8",
@@ -189,6 +233,10 @@ def mysql_8_service(
         docker_service=docker_service,
         isolation_level=xdist_mysql_isolation_level,
         platform=platform,
+        user=mysql_user,
+        password=mysql_password,
+        root_password=mysql_root_password,
+        database=mysql_database,
     ) as service:
         yield service
 
@@ -198,6 +246,10 @@ def mysql_84_service(
     docker_service: DockerService,
     xdist_mysql_isolation_level: XdistIsolationLevel,
     platform: str,
+    mysql_user: str,
+    mysql_password: str,
+    mysql_root_password: str,
+    mysql_database: str,
 ) -> Generator[MySQLService, None, None]:
     with _provide_mysql_service(
         image="mysql:8.4",
@@ -205,6 +257,10 @@ def mysql_84_service(
         docker_service=docker_service,
         isolation_level=xdist_mysql_isolation_level,
         platform=platform,
+        user=mysql_user,
+        password=mysql_password,
+        root_password=mysql_root_password,
+        database=mysql_database,
     ) as service:
         yield service
 
@@ -214,6 +270,10 @@ def mysql_96_service(
     docker_service: DockerService,
     xdist_mysql_isolation_level: XdistIsolationLevel,
     platform: str,
+    mysql_user: str,
+    mysql_password: str,
+    mysql_root_password: str,
+    mysql_database: str,
 ) -> Generator[MySQLService, None, None]:
     with _provide_mysql_service(
         image="mysql:9.6",
@@ -221,160 +281,9 @@ def mysql_96_service(
         docker_service=docker_service,
         isolation_level=xdist_mysql_isolation_level,
         platform=platform,
+        user=mysql_user,
+        password=mysql_password,
+        root_password=mysql_root_password,
+        database=mysql_database,
     ) as service:
         yield service
-
-
-@pytest.fixture(scope="session")
-def mysql_56_connection(mysql_56_service: MySQLService) -> Generator[Any, None, None]:
-    warnings.warn(
-        "The 'mysql_56_connection' fixture is deprecated and will be removed in a future release. "
-        "To recreate this connection, you can use the following snippet:\n\n"
-        "import mysql.connector\n\n"
-        '@pytest.fixture(scope="session")\n'
-        "def my_mysql_connection(mysql_56_service):\n"
-        "    with mysql.connector.connect(\n"
-        "        host=mysql_56_service.host,\n"
-        "        port=mysql_56_service.port,\n"
-        "        user=mysql_56_service.user,\n"
-        "        database=mysql_56_service.db,\n"
-        "        password=mysql_56_service.password,\n"
-        "    ) as conn:\n"
-        "        yield conn",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import mysql.connector  # noqa: PLC0415
-    with mysql.connector.connect(
-        host=mysql_56_service.host,
-        port=mysql_56_service.port,
-        user=mysql_56_service.user,
-        database=mysql_56_service.db,
-        password=mysql_56_service.password,
-    ) as conn:
-        yield conn
-
-
-@pytest.fixture(scope="session")
-def mysql_57_connection(mysql_57_service: MySQLService) -> Generator[Any, None, None]:
-    warnings.warn(
-        "The 'mysql_57_connection' fixture is deprecated and will be removed in a future release. "
-        "To recreate this connection, you can use the following snippet:\n\n"
-        "import mysql.connector\n\n"
-        '@pytest.fixture(scope="session")\n'
-        "def my_mysql_connection(mysql_57_service):\n"
-        "    with mysql.connector.connect(\n"
-        "        host=mysql_57_service.host,\n"
-        "        port=mysql_57_service.port,\n"
-        "        user=mysql_57_service.user,\n"
-        "        database=mysql_57_service.db,\n"
-        "        password=mysql_57_service.password,\n"
-        "    ) as conn:\n"
-        "        yield conn",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import mysql.connector  # noqa: PLC0415
-    with mysql.connector.connect(
-        host=mysql_57_service.host,
-        port=mysql_57_service.port,
-        user=mysql_57_service.user,
-        database=mysql_57_service.db,
-        password=mysql_57_service.password,
-    ) as conn:
-        yield conn
-
-
-@pytest.fixture(scope="session")
-def mysql_connection(mysql_84_connection: Any) -> Any:
-    return mysql_84_connection
-
-
-@pytest.fixture(scope="session")
-def mysql_8_connection(mysql_8_service: MySQLService) -> Generator[Any, None, None]:
-    warnings.warn(
-        "The 'mysql_8_connection' fixture is deprecated and will be removed in a future release. "
-        "To recreate this connection, you can use the following snippet:\n\n"
-        "import mysql.connector\n\n"
-        '@pytest.fixture(scope="session")\n'
-        "def my_mysql_connection(mysql_8_service):\n"
-        "    with mysql.connector.connect(\n"
-        "        host=mysql_8_service.host,\n"
-        "        port=mysql_8_service.port,\n"
-        "        user=mysql_8_service.user,\n"
-        "        database=mysql_8_service.db,\n"
-        "        password=mysql_8_service.password,\n"
-        "    ) as conn:\n"
-        "        yield conn",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import mysql.connector  # noqa: PLC0415
-    with mysql.connector.connect(
-        host=mysql_8_service.host,
-        port=mysql_8_service.port,
-        user=mysql_8_service.user,
-        database=mysql_8_service.db,
-        password=mysql_8_service.password,
-    ) as conn:
-        yield conn
-
-
-@pytest.fixture(scope="session")
-def mysql_84_connection(mysql_84_service: MySQLService) -> Generator[Any, None, None]:
-    warnings.warn(
-        "The 'mysql_84_connection' fixture is deprecated and will be removed in a future release. "
-        "To recreate this connection, you can use the following snippet:\n\n"
-        "import mysql.connector\n\n"
-        '@pytest.fixture(scope="session")\n'
-        "def my_mysql_connection(mysql_84_service):\n"
-        "    with mysql.connector.connect(\n"
-        "        host=mysql_84_service.host,\n"
-        "        port=mysql_84_service.port,\n"
-        "        user=mysql_84_service.user,\n"
-        "        database=mysql_84_service.db,\n"
-        "        password=mysql_84_service.password,\n"
-        "    ) as conn:\n"
-        "        yield conn",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import mysql.connector  # noqa: PLC0415
-    with mysql.connector.connect(
-        host=mysql_84_service.host,
-        port=mysql_84_service.port,
-        user=mysql_84_service.user,
-        database=mysql_84_service.db,
-        password=mysql_84_service.password,
-    ) as conn:
-        yield conn
-
-
-@pytest.fixture(scope="session")
-def mysql_96_connection(mysql_96_service: MySQLService) -> Generator[Any, None, None]:
-    warnings.warn(
-        "The 'mysql_96_connection' fixture is deprecated and will be removed in a future release. "
-        "To recreate this connection, you can use the following snippet:\n\n"
-        "import mysql.connector\n\n"
-        '@pytest.fixture(scope="session")\n'
-        "def my_mysql_connection(mysql_96_service):\n"
-        "    with mysql.connector.connect(\n"
-        "        host=mysql_96_service.host,\n"
-        "        port=mysql_96_service.port,\n"
-        "        user=mysql_96_service.user,\n"
-        "        database=mysql_96_service.db,\n"
-        "        password=mysql_96_service.password,\n"
-        "    ) as conn:\n"
-        "        yield conn",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import mysql.connector  # noqa: PLC0415
-    with mysql.connector.connect(
-        host=mysql_96_service.host,
-        port=mysql_96_service.port,
-        user=mysql_96_service.user,
-        database=mysql_96_service.db,
-        password=mysql_96_service.password,
-    ) as conn:
-        yield conn

--- a/src/pytest_databases/docker/redis.py
+++ b/src/pytest_databases/docker/redis.py
@@ -108,9 +108,12 @@ def dragonfly_service(
         name=name,
         transient=xdist_redis_isolation_level == "server",
     ) as service:
-        yield RedisService(            host=service.host,
+        yield RedisService(
+            host=service.host,
             port=service.port,
-            container=service.container, db=db)
+            container=service.container,
+            db=db,
+        )
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -150,9 +153,12 @@ def keydb_service(
         name=name,
         transient=xdist_redis_isolation_level == "server",
     ) as service:
-        yield RedisService(            host=service.host,
+        yield RedisService(
+            host=service.host,
             port=service.port,
-            container=service.container,db=db)
+            container=service.container,
+            db=db,
+        )
 
 
 @pytest.fixture(autouse=False, scope="session")

--- a/src/pytest_databases/docker/yugabyte.py
+++ b/src/pytest_databases/docker/yugabyte.py
@@ -1,18 +1,45 @@
 from __future__ import annotations
 
+import shlex
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import psycopg
 import pytest
+from docker.errors import ContainerError
 
-from pytest_databases._service import DockerService, ServiceContainer
 from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterator
 
+    from docker.models.containers import Container
+
+    from pytest_databases._service import DockerService
     from pytest_databases.types import XdistIsolationLevel
+
+
+YUGABYTE_USER = "yugabyte"
+YUGABYTE_PASSWORD = "yugabyte"
+YUGABYTE_DB = "yugabyte"
+YUGABYTE_DATABASE = "pytest_databases"
+
+
+def _output_to_bytes(output: bytes | str | Iterator[bytes]) -> bytes:
+    if isinstance(output, bytes):
+        return output
+    if isinstance(output, str):
+        return output.encode()
+    return b"".join(output)
+
+
+def _quote_identifier(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _quote_literal(value: str) -> str:
+    return f"'{value.replace(chr(39), chr(39) * 2)}'"
 
 
 @pytest.fixture(scope="session")
@@ -23,12 +50,8 @@ def xdist_yugabyte_isolation_level() -> XdistIsolationLevel:
 @dataclass
 class YugabyteService(ServiceContainer):
     database: str
-    driver_opts: dict[str, str]
-
-
-@pytest.fixture(scope="session")
-def yugabyte_driver_opts() -> dict[str, str]:
-    return {"sslmode": "disable"}
+    user: str
+    password: str
 
 
 @pytest.fixture(scope="session")
@@ -37,27 +60,203 @@ def yugabyte_image() -> str:
 
 
 @pytest.fixture(scope="session")
-def yugabyte_service(
+def yugabyte_user() -> str:
+    return YUGABYTE_USER
+
+
+@pytest.fixture(scope="session")
+def yugabyte_password() -> str:
+    return YUGABYTE_PASSWORD
+
+
+@pytest.fixture(scope="session")
+def yugabyte_database() -> str:
+    return YUGABYTE_DATABASE
+
+
+def _make_ysqlsh_command(
+    sql: str,
+    *,
+    database: str = YUGABYTE_DB,
+    user: str = YUGABYTE_USER,
+    host: str = "$(hostname)",
+    port: int | None = None,
+) -> str:
+    command_parts = [
+        "bin/ysqlsh",
+        f"-h {host}",
+    ]
+    if port is not None:
+        command_parts.append(f"-p {port}")
+    command_parts.extend([
+        f"-U {shlex.quote(user)}",
+        f"-d {shlex.quote(database)}",
+        "-tAc",
+        shlex.quote(sql),
+    ])
+    return " ".join(command_parts)
+
+
+def _exec_ysqlsh(
+    container: Container,
+    sql: str,
+    *,
+    database: str = YUGABYTE_DB,
+    user: str = YUGABYTE_USER,
+    password: str | None = None,
+) -> tuple[int, bytes]:
+    environment = {"PGPASSWORD": password} if password is not None else None
+    result = container.exec_run([
+        "sh",
+        "-c",
+        _make_ysqlsh_command(sql, database=database, user=user),
+    ], environment=environment)
+    return result.exit_code if result.exit_code is not None else -1, _output_to_bytes(result.output)
+
+
+def _make_role_sql(user: str, password: str) -> str:
+    quoted_user = _quote_identifier(user)
+    quoted_password = _quote_literal(password)
+    quoted_user_literal = _quote_literal(user)
+    return (
+        "DO $$ BEGIN "
+        f"IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = {quoted_user_literal}) THEN "
+        f"CREATE ROLE {quoted_user} LOGIN PASSWORD {quoted_password}; "
+        "ELSE "
+        f"ALTER ROLE {quoted_user} WITH LOGIN PASSWORD {quoted_password}; "
+        "END IF; "
+        "END $$;"
+    )
+
+
+def _ensure_yugabyte_role(container: Container, user: str, password: str) -> tuple[bool, bytes]:
+    exit_code, output = _exec_ysqlsh(container, _make_role_sql(user, password))
+    return exit_code == 0, output
+
+
+def _ensure_yugabyte_database(container: Container, database: str, user: str) -> tuple[bool, bytes]:
+    quoted_database = _quote_identifier(database)
+    quoted_database_literal = _quote_literal(database)
+    quoted_user = _quote_identifier(user)
+    exists_code, exists_output = _exec_ysqlsh(
+        container,
+        f"SELECT 1 FROM pg_database WHERE datname = {quoted_database_literal}",
+    )
+    if exists_code != 0:
+        return False, exists_output
+
+    if exists_output.strip() != b"1":
+        create_code, create_output = _exec_ysqlsh(container, f"CREATE DATABASE {quoted_database} OWNER {quoted_user}")
+        if create_code != 0:
+            return False, create_output
+
+    grant_code, grant_output = _exec_ysqlsh(
+        container,
+        f"GRANT ALL PRIVILEGES ON DATABASE {quoted_database} TO {quoted_user}",
+    )
+    if grant_code != 0:
+        return False, grant_output
+
+    schema_code, schema_output = _exec_ysqlsh(
+        container,
+        f"GRANT ALL PRIVILEGES ON SCHEMA public TO {quoted_user}",
+        database=database,
+    )
+    return schema_code == 0, schema_output
+
+
+def _verify_yugabyte_database_access(
+    container: Container,
+    database: str,
+    user: str,
+    password: str,
+) -> tuple[bool, bytes]:
+    exit_code, output = _exec_ysqlsh(
+        container,
+        "SELECT 1",
+        database=database,
+        user=user,
+        password=password,
+    )
+    return exit_code == 0 and output.strip() == b"1", output
+
+
+def _prepare_yugabyte_database(
+    container: Container,
+    container_name: str,
+    database: str,
+    user: str,
+    password: str,
+) -> None:
+    last_output = b""
+    for attempt in range(15):
+        role_ready, role_output = _ensure_yugabyte_role(container, user, password)
+        database_ready, database_output = _ensure_yugabyte_database(container, database, user) if role_ready else (False, role_output)
+        access_ready, access_output = (
+            _verify_yugabyte_database_access(container, database, user, password) if database_ready else (False, database_output)
+        )
+        if access_ready:
+            return
+
+        last_output = access_output
+        time.sleep(1 + attempt * 0.5)
+
+    msg = (
+        f"Yugabyte fixture {container_name!r}: user {user!r} could not reach database "
+        f"{database!r} after 15 attempts. Last output: {last_output!r}"
+    )
+    raise RuntimeError(msg)
+
+
+def _validate_mapped_endpoint(
     docker_service: DockerService,
+    image: str,
+    service: ServiceContainer,
+    database: str,
+    user: str,
+    password: str,
+) -> tuple[int, bytes]:
+    try:
+        output = docker_service._client.containers.run(
+            image=image,
+            command=[
+                "sh",
+                "-c",
+                _make_ysqlsh_command(
+                    "SELECT 1",
+                    database=database,
+                    user=user,
+                    host=service.host,
+                    port=service.port,
+                ),
+            ],
+            environment={"PGPASSWORD": password},
+            network_mode="host",
+            remove=True,
+        )
+    except ContainerError as exc:
+        return exc.exit_status, _output_to_bytes(exc.stderr) if exc.stderr else str(exc).encode()
+    return 0, _output_to_bytes(output)
+
+
+@pytest.fixture(scope="session")
+def yugabyte_service(
+    docker_service: "DockerService",
     xdist_yugabyte_isolation_level: XdistIsolationLevel,
-    yugabyte_driver_opts: dict[str, str],
     yugabyte_image: str,
+    yugabyte_user: str,
+    yugabyte_password: str,
+    yugabyte_database: str,
 ) -> Generator[YugabyteService, None, None]:
     def yugabyte_responsive(_service: ServiceContainer) -> bool:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_driver_opts.items()) if yugabyte_driver_opts else ""
-        try:
-            conn = psycopg.connect(f"postgresql://yugabyte:yugabyte@{_service.host}:{_service.port}/yugabyte?{opts}")
-        except Exception:  # noqa: BLE001
+        container = docker_service._get_container(f"pytest_databases_{container_name}")
+        if container is None:
             return False
-
-        try:
-            db_open = conn.execute("SELECT 1").fetchone()
-            return bool(db_open is not None and db_open[0] == 1)
-        finally:
-            conn.close()
+        exit_code, output = _exec_ysqlsh(container, "SELECT 1")
+        return exit_code == 0 and output.strip() == b"1"
 
     container_name = "yugabyte"
-    db_name = "pytest_databases"
+    db_name = yugabyte_database
     worker_num = get_xdist_worker_num()
     if worker_num is not None:
         suffix = f"_{worker_num}"
@@ -68,30 +267,53 @@ def yugabyte_service(
 
     with docker_service.run(
         image=yugabyte_image,
-        container_port=5433,  # YugabyteDB YSQL port (not CockroachDB's 26257)
+        container_port=5433,  # YugabyteDB YSQL port
         check=yugabyte_responsive,
         name=container_name,
         command="bin/yugabyted start --background=false",
-        exec_after_start=f"sh -c 'bin/ysqlsh -h $(hostname) -U yugabyte -d yugabyte -c \"CREATE DATABASE {db_name};\"'",
         transient=xdist_yugabyte_isolation_level == "server",
-        timeout=60,  # YugabyteDB needs longer startup time
+        timeout=120,
+        pause=1.0,
     ) as service:
+        container = docker_service._get_container(f"pytest_databases_{container_name}")
+        if container is None:
+            msg = f"Yugabyte container {container_name!r} disappeared after startup"
+            raise RuntimeError(msg)
+
+        _prepare_yugabyte_database(
+            container,
+            container_name,
+            db_name,
+            yugabyte_user,
+            yugabyte_password,
+        )
+
+        last_output = b""
+        for attempt in range(5):
+            endpoint_code, endpoint_output = _validate_mapped_endpoint(
+                docker_service,
+                yugabyte_image,
+                service,
+                db_name,
+                yugabyte_user,
+                yugabyte_password,
+            )
+            if endpoint_code == 0 and endpoint_output.strip() == b"1":
+                break
+            last_output = endpoint_output
+            time.sleep(1 + attempt * 0.5)
+        else:
+            msg = (
+                f"Yugabyte fixture {container_name!r}: mapped endpoint {service.host}:{service.port} "
+                f"was not ready after 5 attempts. Last output: {last_output!r}"
+            )
+            raise RuntimeError(msg)
+
         yield YugabyteService(
             host=service.host,
             port=service.port,
             container=service.container,
             database=db_name,
-            driver_opts=yugabyte_driver_opts,
+            user=yugabyte_user,
+            password=yugabyte_password,
         )
-
-
-@pytest.fixture(scope="session")
-def yugabyte_connection(
-    yugabyte_service: YugabyteService,
-    yugabyte_driver_opts: dict[str, str],
-) -> Generator[psycopg.Connection, None, None]:
-    opts = "&".join(f"{k}={v}" for k, v in yugabyte_driver_opts.items()) if yugabyte_driver_opts else ""
-    with psycopg.connect(
-        f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}"
-    ) as conn:
-        yield conn

--- a/src/pytest_databases/types.py
+++ b/src/pytest_databases/types.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from docker.models.containers import Container
+if TYPE_CHECKING:
+    from docker.models.containers import Container
 
 
 @dataclasses.dataclass

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -13,43 +13,27 @@ import pytest
 )
 def test_service_fixture(pytester: pytest.Pytester, service_fixture: str) -> None:
     pytester.makepyfile(f"""
-    import mysql.connector
     pytest_plugins = ["pytest_databases.docker.mysql"]
+
+    def run_mysql(service, sql):
+        result = service.container.exec_run(
+            [
+                "mysql",
+                f"--user={{service.user}}",
+                "-D",
+                service.db,
+                "--batch",
+                "--skip-column-names",
+                "-e",
+                sql,
+            ],
+            environment={{"MYSQL_PWD": service.password}},
+        )
+        assert result.exit_code == 0, result.output.decode(errors="replace")
+        return result.output.decode().strip()
 
     def test({service_fixture}):
-        with mysql.connector.connect(
-            host={service_fixture}.host,
-            port={service_fixture}.port,
-            user={service_fixture}.user,
-            database={service_fixture}.db,
-            password={service_fixture}.password,
-        ) as conn, conn.cursor() as cursor:
-            cursor.execute("select 1 as is_available")
-            resp = cursor.fetchone()
-        assert resp is not None and resp[0] == 1
-    """)
-
-    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
-    result.assert_outcomes(passed=1)
-
-
-@pytest.mark.parametrize(
-    "connection_fixture",
-    [
-    "mysql_56_connection",
-    "mysql_57_connection",
-    ],
-)
-def test_connection_fixture(pytester: pytest.Pytester, connection_fixture: str) -> None:
-    pytester.makepyfile(f"""
-    pytest_plugins = ["pytest_databases.docker.mysql"]
-
-    def test({connection_fixture}):
-        with {connection_fixture}.cursor() as cursor:
-            cursor.execute("CREATE TABLE if not exists simple_table as SELECT 1 as the_value")
-            cursor.execute("select * from simple_table")
-            result = cursor.fetchall()
-            assert result is not None and result[0][0] == 1
+        assert run_mysql({service_fixture}, "select 1 as is_available") == "1"
     """)
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
@@ -60,13 +44,25 @@ def test_xdist_isolate_database(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
     pytest_plugins = ["pytest_databases.docker.mysql"]
 
-    def test_1(mysql_56_connection):
-        with mysql_56_connection.cursor() as cursor:
-            cursor.execute("CREATE TABLE simple_table as SELECT 1 as the_value;")
+    def run_mysql(service, sql):
+        result = service.container.exec_run(
+            [
+                "mysql",
+                f"--user={service.user}",
+                "-D",
+                service.db,
+                "-e",
+                sql,
+            ],
+            environment={"MYSQL_PWD": service.password},
+        )
+        assert result.exit_code == 0, result.output.decode(errors="replace")
 
-    def test_2(mysql_56_connection):
-        with mysql_56_connection.cursor() as cursor:
-            cursor.execute("CREATE TABLE simple_table as SELECT 1 as the_value;")
+    def test_1(mysql_56_service):
+        run_mysql(mysql_56_service, "CREATE TABLE simple_table as SELECT 1 as the_value;")
+
+    def test_2(mysql_56_service):
+        run_mysql(mysql_56_service, "CREATE TABLE simple_table as SELECT 1 as the_value;")
     """)
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")
@@ -82,13 +78,25 @@ def test_xdist_isolate_server(pytester: pytest.Pytester) -> None:
     def xdist_mysql_isolation_level():
         return "server"
 
-    def test_1(mysql_56_connection):
-        with mysql_56_connection.cursor() as cursor:
-            cursor.execute("CREATE DATABASE db_test")
+    def run_mysql(service, sql):
+        result = service.container.exec_run(
+            [
+                "mysql",
+                f"--user={service.user}",
+                "-D",
+                service.db,
+                "-e",
+                sql,
+            ],
+            environment={"MYSQL_PWD": service.password},
+        )
+        assert result.exit_code == 0, result.output.decode(errors="replace")
 
-    def test_2(mysql_56_connection):
-        with mysql_56_connection.cursor() as cursor:
-            cursor.execute("CREATE DATABASE db_test")
+    def test_1(mysql_56_service):
+        run_mysql(mysql_56_service, "CREATE DATABASE db_test")
+
+    def test_2(mysql_56_service):
+        run_mysql(mysql_56_service, "CREATE DATABASE db_test")
     """)
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")

--- a/tests/test_yugabyte.py
+++ b/tests/test_yugabyte.py
@@ -9,37 +9,43 @@ if TYPE_CHECKING:
 def test_service_fixture(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
     import pytest
-    import psycopg
-    from pytest_databases.docker.postgres import _make_connection_string  # noqa: PLC2701
+    import shlex
 
     pytest_plugins = ["pytest_databases.docker.yugabyte"]
+
+    @pytest.fixture(scope="session")
+    def yugabyte_user():
+        return "custom_yugabyte_user"
+
+    @pytest.fixture(scope="session")
+    def yugabyte_password():
+        return "custom-yugabyte-password"
+
+    @pytest.fixture(scope="session")
+    def yugabyte_database():
+        return "custom_yugabyte_database"
+
+    def run_ysqlsh(yugabyte_service, sql, database=None):
+        database = database or yugabyte_service.database
+        command = " ".join([
+            "bin/ysqlsh",
+            "-h $(hostname)",
+            f"-U {shlex.quote(yugabyte_service.user)}",
+            f"-d {shlex.quote(database)}",
+            "-tAc",
+            shlex.quote(sql),
+        ])
+        result = yugabyte_service.container.exec_run(["sh", "-c", command])
+        assert result.exit_code == 0, result.output.decode(errors="replace")
+        return result.output.decode().strip()
 
     def test(yugabyte_service) -> None:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        with psycopg.connect(
-            f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}"
-        ) as conn:
-            db_open = conn.execute("SELECT 1").fetchone()
-            assert db_open is not None and db_open[0] == 1
-    """)
-
-    result = pytester.runpytest_subprocess("-p", "pytest_databases")
-    result.assert_outcomes(passed=1)
-
-
-def test_startup_connection_fixture(pytester: pytest.Pytester) -> None:
-    pytester.makepyfile("""
-    import pytest
-    import psycopg
-    from pytest_databases.docker.postgres import _make_connection_string  # noqa: PLC2701
-
-
-    pytest_plugins = ["pytest_databases.docker.yugabyte"]
-
-    def test(yugabyte_connection) -> None:
-        yugabyte_connection.execute("CREATE TABLE if not exists simple_table as SELECT 1")
-        result = yugabyte_connection.execute("select * from simple_table").fetchone()
-        assert result is not None and result[0] == 1
+        assert yugabyte_service.user == "custom_yugabyte_user"
+        assert yugabyte_service.password == "custom-yugabyte-password"
+        assert yugabyte_service.database == "custom_yugabyte_database"
+        assert run_ysqlsh(yugabyte_service, "SELECT 1") == "1"
+        run_ysqlsh(yugabyte_service, "CREATE TABLE IF NOT EXISTS simple_table AS SELECT 1")
+        assert run_ysqlsh(yugabyte_service, "SELECT * FROM simple_table") == "1"
     """)
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases")
@@ -49,24 +55,27 @@ def test_startup_connection_fixture(pytester: pytest.Pytester) -> None:
 def test_xdist_isolate_database(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
     import pytest
-    import psycopg
-    from pytest_databases.docker.postgres import _make_connection_string
+    import shlex
 
     pytest_plugins = ["pytest_databases.docker.yugabyte"]
 
+    def run_ysqlsh(yugabyte_service, sql):
+        command = " ".join([
+            "bin/ysqlsh",
+            "-h $(hostname)",
+            f"-U {shlex.quote(yugabyte_service.user)}",
+            f"-d {shlex.quote(yugabyte_service.database)}",
+            "-c",
+            shlex.quote(sql),
+        ])
+        result = yugabyte_service.container.exec_run(["sh", "-c", command])
+        assert result.exit_code == 0, result.output.decode(errors="replace")
+
     def test_one(yugabyte_service) -> None:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        with psycopg.connect(
-            f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}"
-        ) as conn:
-            conn.execute("CREATE TABLE foo AS SELECT 1")
+        run_ysqlsh(yugabyte_service, "CREATE TABLE foo AS SELECT 1")
 
     def test_two(yugabyte_service) -> None:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        with psycopg.connect(
-            f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}"
-        ) as conn:
-            conn.execute("CREATE TABLE foo AS SELECT 1")
+        run_ysqlsh(yugabyte_service, "CREATE TABLE foo AS SELECT 1")
     """)
 
     result = pytester.runpytest_subprocess("-n", "2")
@@ -76,8 +85,7 @@ def test_xdist_isolate_database(pytester: pytest.Pytester) -> None:
 def test_xdist_isolate_server(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
     import pytest
-    import psycopg
-    from pytest_databases.docker.postgres import _make_connection_string
+    import shlex
 
     pytest_plugins = ["pytest_databases.docker.yugabyte"]
 
@@ -85,21 +93,23 @@ def test_xdist_isolate_server(pytester: pytest.Pytester) -> None:
     def xdist_yugabyte_isolation_level():
         return "server"
 
+    def run_ysqlsh(yugabyte_service, sql, database="yugabyte"):
+        command = " ".join([
+            "bin/ysqlsh",
+            "-h $(hostname)",
+            f"-U {shlex.quote(yugabyte_service.user)}",
+            f"-d {shlex.quote(database)}",
+            "-c",
+            shlex.quote(sql),
+        ])
+        result = yugabyte_service.container.exec_run(["sh", "-c", command])
+        assert result.exit_code == 0, result.output.decode(errors="replace")
+
     def test_one(yugabyte_service) -> None:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        with psycopg.connect(
-            f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}",
-            autocommit=True,
-        ) as conn:
-            conn.execute("CREATE DATABASE foo")
+        run_ysqlsh(yugabyte_service, "CREATE DATABASE foo")
 
     def test_two(yugabyte_service) -> None:
-        opts = "&".join(f"{k}={v}" for k, v in yugabyte_service.driver_opts.items())
-        with psycopg.connect(
-            f"postgresql://yugabyte:yugabyte@{yugabyte_service.host}:{yugabyte_service.port}/{yugabyte_service.database}?{opts}",
-            autocommit=True,
-        ) as conn:
-            conn.execute("CREATE DATABASE foo")
+        run_ysqlsh(yugabyte_service, "CREATE DATABASE foo")
     """)
 
     result = pytester.runpytest_subprocess("-n", "2")

--- a/uv.lock
+++ b/uv.lock
@@ -2588,85 +2588,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mysql-connector-python"
-version = "9.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/77/2b45e6460d05b1f1b7a4c8eb79a50440b4417971973bb78c9ef6cad630a6/mysql_connector_python-9.4.0.tar.gz", hash = "sha256:d111360332ae78933daf3d48ff497b70739aa292ab0017791a33e826234e743b", size = 12185532, upload-time = "2025-07-22T08:02:05.788Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/ef/1a35d9ebfaf80cf5aa238be471480e16a69a494d276fb07b889dc9a5cfc3/mysql_connector_python-9.4.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:3c2603e00516cf4208c6266e85c5c87d5f4d0ac79768106d50de42ccc8414c05", size = 17501678, upload-time = "2025-07-22T07:57:23.237Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/39/09ae7082c77a978f2d72d94856e2e57906165c645693bc3a940bcad3a32d/mysql_connector_python-9.4.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:47884fcb050112b8bef3458e17eac47cc81a6cbbf3524e3456146c949772d9b4", size = 18369526, upload-time = "2025-07-22T07:57:27.569Z" },
-    { url = "https://files.pythonhosted.org/packages/40/56/1bea00f5129550bcd0175781b9cd467e865d4aea4a6f38f700f34d95dcb8/mysql_connector_python-9.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f14b6936cd326e212fc9ab5f666dea3efea654f0cb644460334e60e22986e735", size = 33508525, upload-time = "2025-07-22T07:57:32.935Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ec/86dfefd3e6c0fca13085bc28b7f9baae3fce9f6af243d8693729f6b5063c/mysql_connector_python-9.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0f5ad70355720e64b72d7c068e858c9fd1f69b671d9575f857f235a10f878939", size = 33911834, upload-time = "2025-07-22T07:57:38.203Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/11/6907d53349b11478f72c8f22e38368d18262fbffc27e0f30e365d76dad93/mysql_connector_python-9.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:7106670abce510e440d393e27fc3602b8cf21e7a8a80216cc9ad9a68cd2e4595", size = 16393044, upload-time = "2025-07-22T07:57:42.053Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0c/4365a802129be9fa63885533c38be019f1c6b6f5bcf8844ac53902314028/mysql_connector_python-9.4.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7df1a8ddd182dd8adc914f6dc902a986787bf9599705c29aca7b2ce84e79d361", size = 17501627, upload-time = "2025-07-22T07:57:45.416Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/bf/ca596c00d7a6eaaf8ef2f66c9b23cd312527f483073c43ffac7843049cb4/mysql_connector_python-9.4.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:3892f20472e13e63b1fb4983f454771dd29f211b09724e69a9750e299542f2f8", size = 18369494, upload-time = "2025-07-22T07:57:49.714Z" },
-    { url = "https://files.pythonhosted.org/packages/25/14/6510a11ed9f80d77f743dc207773092c4ab78d5efa454b39b48480315d85/mysql_connector_python-9.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d3e87142103d71c4df647ece30f98e85e826652272ed1c74822b56f6acdc38e7", size = 33516187, upload-time = "2025-07-22T07:57:55.294Z" },
-    { url = "https://files.pythonhosted.org/packages/16/a8/4f99d80f1cf77733ce9a44b6adb7f0dd7079e7afa51ca4826515ef0c3e16/mysql_connector_python-9.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b27fcd403436fe83bafb2fe7fcb785891e821e639275c4ad3b3bd1e25f533206", size = 33917818, upload-time = "2025-07-22T07:58:00.523Z" },
-    { url = "https://files.pythonhosted.org/packages/15/9c/127f974ca9d5ee25373cb5433da06bb1f36e05f2a6b7436da1fe9c6346b0/mysql_connector_python-9.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd6ff5afb9c324b0bbeae958c93156cce4168c743bf130faf224d52818d1f0ee", size = 16392378, upload-time = "2025-07-22T07:58:04.669Z" },
-    { url = "https://files.pythonhosted.org/packages/03/7c/a543fb17c2dfa6be8548dfdc5879a0c7924cd5d1c79056c48472bb8fe858/mysql_connector_python-9.4.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:4efa3898a24aba6a4bfdbf7c1f5023c78acca3150d72cc91199cca2ccd22f76f", size = 17503693, upload-time = "2025-07-22T07:58:08.96Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/6e/c22fbee05f5cfd6ba76155b6d45f6261d8d4c1e36e23de04e7f25fbd01a4/mysql_connector_python-9.4.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:665c13e7402235162e5b7a2bfdee5895192121b64ea455c90a81edac6a48ede5", size = 18371987, upload-time = "2025-07-22T07:58:13.273Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/fd/f426f5f35a3d3180c7f84d1f96b4631be2574df94ca1156adab8618b236c/mysql_connector_python-9.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:815aa6cad0f351c1223ef345781a538f2e5e44ef405fdb3851eb322bd9c4ca2b", size = 33516214, upload-time = "2025-07-22T07:58:18.967Z" },
-    { url = "https://files.pythonhosted.org/packages/45/5a/1b053ae80b43cd3ccebc4bb99a98826969b3b0f8adebdcc2530750ad76ed/mysql_connector_python-9.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b3436a2c8c0ec7052932213e8d01882e6eb069dbab33402e685409084b133a1c", size = 33918565, upload-time = "2025-07-22T07:58:25.28Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/69/36b989de675d98ba8ff7d45c96c30c699865c657046f2e32db14e78f13d9/mysql_connector_python-9.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:57b0c224676946b70548c56798d5023f65afa1ba5b8ac9f04a143d27976c7029", size = 16392563, upload-time = "2025-07-22T07:58:29.623Z" },
-    { url = "https://files.pythonhosted.org/packages/79/e2/13036479cd1070d1080cee747de6c96bd6fbb021b736dd3ccef2b19016c8/mysql_connector_python-9.4.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:fde3bbffb5270a4b02077029914e6a9d2ec08f67d8375b4111432a2778e7540b", size = 17503749, upload-time = "2025-07-22T07:58:33.649Z" },
-    { url = "https://files.pythonhosted.org/packages/31/df/b89e6551b91332716d384dcc3223e1f8065902209dcd9e477a3df80154f7/mysql_connector_python-9.4.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:25f77ad7d845df3b5a5a3a6a8d1fed68248dc418a6938a371d1ddaaab6b9a8e3", size = 18372145, upload-time = "2025-07-22T07:58:37.384Z" },
-    { url = "https://files.pythonhosted.org/packages/07/bd/af0de40a01d5cb4df19318cc018e64666f2b7fa89bffa1ab5b35337aae2c/mysql_connector_python-9.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:227dd420c71e6d4788d52d98f298e563f16b6853577e5ade4bd82d644257c812", size = 33516503, upload-time = "2025-07-22T07:58:41.987Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/9b/712053216fcbe695e519ecb1035ffd767c2de9f51ccba15078537c99d6fa/mysql_connector_python-9.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5163381a312d38122eded2197eb5cd7ccf1a5c5881d4e7a6de10d6ea314d088e", size = 33918904, upload-time = "2025-07-22T07:58:46.796Z" },
-    { url = "https://files.pythonhosted.org/packages/64/15/cbd996d425c59811849f3c1d1b1dae089a1ae18c4acd4d8de2b847b772df/mysql_connector_python-9.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:c727cb1f82b40c9aaa7a15ab5cf0a7f87c5d8dce32eab5ff2530a4aa6054e7df", size = 16392566, upload-time = "2025-07-22T07:58:50.223Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/36/b32635b69729f144d45c0cbcd135cfd6c480a62160ac015ca71ebf68fca7/mysql_connector_python-9.4.0-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:20f8154ab5c0ed444f8ef8e5fa91e65215037db102c137b5f995ebfffd309b78", size = 17501675, upload-time = "2025-07-22T07:58:53.049Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/23/65e801f74b3fcc2a6944242d64f0d623af48497e4d9cf55419c2c6d6439b/mysql_connector_python-9.4.0-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:7b8976d89d67c8b0dc452471cb557d9998ed30601fb69a876bf1f0ecaa7954a4", size = 18369579, upload-time = "2025-07-22T07:58:55.995Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e9/dc31eeffe33786016e1370be72f339544ee00034cb702c0b4a3c6f5c1585/mysql_connector_python-9.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:4ee4fe1b067e243aae21981e4b9f9d300a3104814b8274033ca8fc7a89b1729e", size = 33506513, upload-time = "2025-07-22T07:58:59.341Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c7/aa6f4cc2e5e3fb68b5a6bba680429b761e387b8a040cf16a5f17e0b09df6/mysql_connector_python-9.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:1c6b95404e80d003cd452e38674e91528e2b3a089fe505c882f813b564e64f9d", size = 33909982, upload-time = "2025-07-22T07:59:02.832Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a4/b1e2adc65121e7eabed06d09bed87638e7f9a51e9b5dbb1cfb17b58b1181/mysql_connector_python-9.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:a8f820c111335f225d63367307456eb7e10494f87e7a94acded3bb762e55a6d4", size = 16393051, upload-time = "2025-07-22T07:59:05.983Z" },
-    { url = "https://files.pythonhosted.org/packages/36/34/b6165e15fd45a8deb00932d8e7d823de7650270873b4044c4db6688e1d8f/mysql_connector_python-9.4.0-py2.py3-none-any.whl", hash = "sha256:56e679169c704dab279b176fab2a9ee32d2c632a866c0f7cd48a8a1e2cf802c4", size = 406574, upload-time = "2025-07-22T07:59:08.394Z" },
-]
-
-[[package]]
-name = "mysql-connector-python"
-version = "9.6.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
-    { url = "https://files.pythonhosted.org/packages/17/97/d3cbab27663d7b5063d891c6bd322db6cf1cdb42d4e0d2d2ec9a1952c67f/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:228000bb951810dad724821d04000174ffcc7fa94b4dcef884b17a3cdae07283", size = 18449353, upload-time = "2026-01-21T09:04:38.032Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/0e14e30dddb8f9a5230c6dbce6f874fba2aeaab1ce971dce3912cf81773e/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:477e86182aefbf693b71ff8bda7679ab4487af64c027759af831a70080aaaeac", size = 34161450, upload-time = "2026-01-21T09:04:40.763Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/80/1b0012fd86b5a7c0952878e33938ccd4b2862eb882e08a502b99348988d0/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4bf932724a2702d8b9cde4bf764b843a35e85c59479a870997d37a2a68a5632d", size = 34533941, upload-time = "2026-01-21T09:04:43.759Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ed/9ff5ff9ea8421ffdf248fa71b9328fd8b9a23e1e3a2a523db5f7d58240c6/mysql_connector_python-9.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:b507372c060eb39e2a10ebcb3eb1b12e1778b0120808062fc23e3856268cd2d9", size = 16515417, upload-time = "2026-01-21T09:04:46.47Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/08/0e9bce000736454c2b8bb4c40bded79328887483689487dad7df4cf59fb7/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:011931f7392a1087e10d305b0303f2a20cc1af2c1c8a15cd5691609aa95dfcbd", size = 17582646, upload-time = "2026-01-21T09:04:48.327Z" },
-    { url = "https://files.pythonhosted.org/packages/93/aa/3dd4db039fc6a9bcbdbade83be9914ead6786c0be4918170dfaf89327b76/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b5212372aff6833473d2560ac87d3df9fb2498d0faacb7ebf231d947175fa36a", size = 18449358, upload-time = "2026-01-21T09:04:50.278Z" },
-    { url = "https://files.pythonhosted.org/packages/53/38/ecd6d35382b6265ff5f030464d53b45e51ff2c2523ab88771c277fd84c05/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:61deca6e243fafbb3cf08ae27bd0c83d0f8188de8456e46aeba0d3db15bb7230", size = 34169309, upload-time = "2026-01-21T09:04:52.402Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1d/fe1133eb76089342854d8fbe88e28598f7e06bc684a763d21fc7b23f1d5e/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:adabbc5e1475cdf5fb6f1902a25edc3bd1e0726fa45f01ab1b8f479ff43b3337", size = 34541101, upload-time = "2026-01-21T09:04:55.897Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/99/da0f55beb970ca049fd7d37a6391d686222af89a8b13e636d8e9bbd06536/mysql_connector_python-9.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:8732ca0b7417b45238bcbfc7e64d9c4d62c759672207c6284f0921c366efddc7", size = 16514767, upload-time = "2026-02-10T12:03:50.584Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/d9/2a4b4d90b52f4241f0f71618cd4bd8779dd6d18db8058b0a4dd83ec0541c/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9664e217c72dd6fb700f4c8512af90261f72d2f5d7c00c4e13e4c1e09bfa3d5e", size = 17585672, upload-time = "2026-02-10T12:03:52.955Z" },
-    { url = "https://files.pythonhosted.org/packages/33/91/2495835733a054e716a17dc28404748b33f2dc1da1ae4396fb45574adf40/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1ed4b5c4761e5333035293e746683890e4ef2e818e515d14023fd80293bc31fa", size = 18452624, upload-time = "2026-02-10T12:03:56.153Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/69/e83abbbbf7f8eed855b5a5ff7285bc0afb1199418ac036c7691edf41e154/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5095758dcb89a6bce2379f349da336c268c407129002b595c5dba82ce387e2a5", size = 34169154, upload-time = "2026-02-10T12:03:58.831Z" },
-    { url = "https://files.pythonhosted.org/packages/82/44/67bb61c71f398fbc739d07e8dcadad94e2f655874cb32ae851454066bea0/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ae4e7780fad950a4f267dea5851048d160f5b71314a342cdbf30b154f1c74f7", size = 34542947, upload-time = "2026-02-10T12:04:02.408Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/39/994c4f7e9c59d3ca534a831d18442ac4c529865db20aeaa4fd94e2af5efd/mysql_connector_python-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c180e0b4100d7402e03993bfac5c97d18e01d7ca9d198d742fffc245077f8ffe", size = 16515709, upload-time = "2026-02-10T12:04:04.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/58/9521aa678708ec6cebfd40524c14c3d151e4f29e3774e6086aa0a30d203b/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e86e45a7b540ca09af8a18ecfa761e0cdeccfdb62818331614ec030ae44bfd26", size = 17585837, upload-time = "2026-02-10T12:04:07.004Z" },
-    { url = "https://files.pythonhosted.org/packages/39/8d/b108f9bcce9780f6a1f91decb2af54defdaf845e237ddc42f2b4578f1cd7/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:8d3e9252384e1b7f95b07020664f2673d9c29c5e95eeda2e048b3331e190b9d4", size = 18452844, upload-time = "2026-02-10T12:04:09.418Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/28/735cd93d16e76dc2feb4abb3f1229a1d9475af34d80c26712fec6abe1d70/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0fa18ead33cb699ea92005695077cef09aa494eebf51164ee30c891c3eaea90c", size = 34169374, upload-time = "2026-02-10T12:04:12.13Z" },
-    { url = "https://files.pythonhosted.org/packages/42/07/069983799cf4050c68f61a494f94b06f095fee6026ab0dd863a14de30867/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a26490cb029bf7b18a1d2093101105b3526a1036b51ad01553d30138f5beb8d2", size = 34543019, upload-time = "2026-02-10T12:04:15.065Z" },
-    { url = "https://files.pythonhosted.org/packages/32/00/fbeb7d666ab8153f719e620bac5abfbc74640e8ec511612493110a75fe66/mysql_connector_python-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:3460ed976e1b88b7284335d9397a3c519dff56d71580ca1f76ff1c0c7714c813", size = 16515701, upload-time = "2026-02-10T12:04:19.26Z" },
-    { url = "https://files.pythonhosted.org/packages/70/51/13cc90b2a703784cd9a0aa0a6fce07946cf6a2abe7c8fd0b585562e250fc/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e2cc13cd3dcdb845d636e52c4e7a9509b63da09bec6ce1b3696be53a79847e2d", size = 17585800, upload-time = "2026-02-10T12:04:21.6Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/6b/ce7ab998fbdd17f35a1b54624365d039045cbb2d42bbc7b03f50d7597c7b/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:a08c2149d4b52a010c4353f18c84716d18114a4ecd00b466ea34138de2c640f2", size = 18452823, upload-time = "2026-02-10T12:04:23.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/8157ed61d17878c33511dcb97c68ecaaaf6220bea5a2944ea4eba73cc63a/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b00228b985edd208b20f45c5e684c54e08e31e01bc1d8c3c18a36641c3be5bf7", size = 34171594, upload-time = "2026-02-10T12:04:27.401Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
-    { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
-]
-
-[[package]]
 name = "myst-parser"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4017,8 +3938,6 @@ dev = [
     { name = "coverage", version = "7.13.5", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "1.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mysql-connector-python", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4135,8 +4054,6 @@ lint = [
 test = [
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.13.5", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
-    { name = "mysql-connector-python", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cdist", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -4171,7 +4088,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'" },
     { name = "valkey", marker = "extra == 'valkey'" },
 ]
-provides-extras = ["azure-storage", "bigquery", "cockroachdb", "dragonfly", "elasticsearch7", "elasticsearch8", "gizmosql", "keydb", "mariadb", "mongodb", "mssql", "oracle", "postgres", "redis", "spanner", "valkey", "yugabyte"]
+provides-extras = ["azure-storage", "bigquery", "cockroachdb", "dragonfly", "elasticsearch7", "elasticsearch8", "gizmosql", "keydb", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres", "redis", "spanner", "valkey", "yugabyte"]
 
 [package.metadata.requires-dev]
 build = [{ name = "bump-my-version" }]
@@ -4180,8 +4097,6 @@ dev = [
     { name = "bump-my-version" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
     { name = "mypy" },
-    { name = "mysql-connector-python", marker = "python_full_version < '3.10'", specifier = "<9.5" },
-    { name = "mysql-connector-python", marker = "python_full_version >= '3.10'", specifier = ">=9.6,<9.7" },
     { name = "myst-parser" },
     { name = "pre-commit" },
     { name = "psycopg", extras = ["binary", "pool"] },
@@ -4256,8 +4171,6 @@ lint = [
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
-    { name = "mysql-connector-python", marker = "python_full_version < '3.10'", specifier = "<9.5" },
-    { name = "mysql-connector-python", marker = "python_full_version >= '3.10'", specifier = ">=9.6,<9.7" },
     { name = "pytest" },
     { name = "pytest-cdist", specifier = ">=0.2" },
     { name = "pytest-click" },

--- a/uv.lock
+++ b/uv.lock
@@ -3131,102 +3131,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4", size = 3712314, upload-time = "2026-04-20T23:33:31.363Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56", size = 3822389, upload-time = "2026-04-20T23:33:34.178Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/30575e75f14d5351a56a1971bb43fe7f8bf7edf1b654fb1bec65c42a8812/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433", size = 4578448, upload-time = "2026-04-20T23:33:37.073Z" },
-    { url = "https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e", size = 4273705, upload-time = "2026-04-20T23:33:39.291Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/8a/c566803818eb03161ba869b6ba612bf7ad56816d98b9e5121e0a22ad6b0b/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3", size = 5893784, upload-time = "2026-04-20T23:33:41.658Z" },
-    { url = "https://files.pythonhosted.org/packages/63/fe/0dfa5797e0b229e0567bc378695224caf14d547f73b05be0c80549089772/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4", size = 4109306, upload-time = "2026-04-20T23:33:43.953Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/89/28063adf17a4ba501eedd9890feab0c649ee4d8bd0a97df0ff1e9584feab/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256", size = 3654400, upload-time = "2026-04-20T23:33:46.115Z" },
-    { url = "https://files.pythonhosted.org/packages/84/94/5a01de0aa4ead0b8d8d1aa4ec18cec0bd36d03fa714eaa5bb8a0b1b50020/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c", size = 3299215, upload-time = "2026-04-20T23:33:48.202Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/85/723bb085a61c6ac2dc0a0043f375f2fe7365363e27b073bad56ca5bda979/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463", size = 3047724, upload-time = "2026-04-20T23:33:50.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/67/4d8b1e0d2fc4166677380eac0edf9cdff91013aca2546e8ef7bc04b56158/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1", size = 3349183, upload-time = "2026-04-20T23:33:59.635Z" },
-    { url = "https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03", size = 2757036, upload-time = "2026-04-20T23:34:01.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
-    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
-    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
-    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
-    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
-    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
-    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
-    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
-    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
-    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/aea5aa8066508dc1b94c6d5d45acb88961a76d1a2a536f08346afd746c08/psycopg2_binary-2.9.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ee2d84ef5eb6c04702d2e9c372ad557fb027f26a5d82804f749dfb14c7fdd2ab", size = 3712300, upload-time = "2026-04-20T23:35:48.393Z" },
-    { url = "https://files.pythonhosted.org/packages/26/78/92cf978d7a73c1e6df828f76d53e4f92466382fa5fbfaf38d29faa64abe0/psycopg2_binary-2.9.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cfa2517c94ea3af6deb46f81e1bbd884faa63e28481eb2f889989dd8d95e5f03", size = 3822404, upload-time = "2026-04-20T23:35:50.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d3/e0137141952bcb709a11dc7121e104d4e55ec7c9a2c27e8e7b28a8954c37/psycopg2_binary-2.9.12-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:ba3df2fc42a1cfa45b72cf096d4acb2b885937eedc61461081d53538d4a82a86", size = 4578512, upload-time = "2026-04-20T23:35:52.209Z" },
-    { url = "https://files.pythonhosted.org/packages/15/f0/4db12fd81531f721dd1f8331b45cbde39a5838413a4cc6055784006c7e91/psycopg2_binary-2.9.12-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:718e1fc18edf573b02cb8aea868de8d8d33f99ce9620206aa9144b67b0985e94", size = 4273721, upload-time = "2026-04-20T23:35:54.393Z" },
-    { url = "https://files.pythonhosted.org/packages/24/39/56131d71e5b12e31665e305744e000d4f931c75a7f5bf4ee6d080925d35b/psycopg2_binary-2.9.12-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5c7cb4cbf894a1d36c720d713de507952c7c58f66d30834708f03dbe5c822ccf", size = 5893802, upload-time = "2026-04-20T23:35:56.699Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ad/248ad71b79fc683e5e20249bf13c28d4c52ae4387b791b17b0faa97e93fa/psycopg2_binary-2.9.12-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:049366c6d884bdcd65d66e6ca1fdbebe670b56c6c9ba46f164e6667e90881964", size = 4109350, upload-time = "2026-04-20T23:35:59.292Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b2/b02b458b4bb0491f50d026812fb472284cf445a04c1646f028157c8dc41a/psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fb1828cf3da68f99e45ebce1355d65d2d12b6a78fb5dfb16247aad6bdef5f5d2", size = 3654422, upload-time = "2026-04-20T23:36:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e1/90666893ceb23e0f4b981c93d20deb7e7b4600becf613f02043a845c6d0f/psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:127467c6e476dd876634f17c3d870530e73ff454ff99bff73d36e80af28e1115", size = 3299252, upload-time = "2026-04-20T23:36:03.21Z" },
-    { url = "https://files.pythonhosted.org/packages/93/a8/700c51aee148a76adc9e01db79d09c6cc82b8a627180503dff4036dbffa9/psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:ace94261f43850e9e79f6c56636c5e0147978ab79eda5e5e5ebf13ae146fc8fe", size = 3047732, upload-time = "2026-04-20T23:36:05.109Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/bc/5411ca76cb8ba9b457b5d0df31cf4ca37b494b22f37d15544520939b53ef/psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a7e39a65b7d2a20e4ba2e0aaad1960b61cc2888d6ab047769f8347bd3c9ad915", size = 3349175, upload-time = "2026-04-20T23:36:07.19Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/2a/1f7571b1d39e44ece80f036b8b54fc498c28507a97e5aba13082599b5971/psycopg2_binary-2.9.12-cp39-cp39-win_amd64.whl", hash = "sha256:f625abb7020e4af3432d95342daa1aa0db3fa369eed19807aa596367ba791b10", size = 2758051, upload-time = "2026-04-20T23:36:09.325Z" },
-]
-
-[[package]]
-name = "psycopg2-yugabytedb"
-version = "2.9.3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/26/c5cc4810c5100e7bd95d6c0799c0a92d9898554d0ca5dfa42c4cef1773fc/psycopg2_yugabytedb-2.9.3.5.tar.gz", hash = "sha256:af41d31a910435377483b0034eba6e0da1f2f8b2b5171e78e9439f8fdd66fdbc", size = 398980, upload-time = "2025-01-31T11:12:26.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/f2/7d8d5c3f792c45c37bf2d67e410d43e34f4794a69b284fdf720c2de1be9a/psycopg2_yugabytedb-2.9.3.5-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:dcfb49c2d94608b365bcd917f8b072f8ee3ca1407e90dc2fee440920ffa672e2", size = 152677, upload-time = "2025-01-31T11:12:22.882Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/65/3d68a705bdd2b3b25f4f5b8ca015d8635e5b4e0d8539b55d57d24e355910/psycopg2_yugabytedb-2.9.3.5-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:f2a590fb536e68af8aee9f5f79f2b342dbe0ed4f8155982b0b666b824db48282", size = 155224, upload-time = "2025-01-31T11:12:25.15Z" },
-]
-
-[[package]]
-name = "psycopg2-yugabytedb-binary"
-version = "2.9.3.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/f7/f21478badfd15ee66a4d463d9c9c333d139243f4b9b34315492648b3e6a1/psycopg2_yugabytedb_binary-2.9.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca4e48fd7661e61828ab1e9a45d2bd10a07eec06ace07f6fca7a199d74fe764", size = 2998390, upload-time = "2025-02-03T12:33:06.053Z" },
-    { url = "https://files.pythonhosted.org/packages/db/33/e263ece61819b8b65d06bbb9aa744e6105ef039dc1e48badefc33851ddd8/psycopg2_yugabytedb_binary-2.9.3.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6356f7556135a72890f81857cfd2cb6ccb4733551914ba40d6f07bf587fe78cf", size = 2998388, upload-time = "2025-02-03T12:33:30.048Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ed/7347689e3ddd9e878af3aa66b8805f6ad56020f43bd04f7f5769466ff361/psycopg2_yugabytedb_binary-2.9.3.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f4a293fab721a46dc9ffbf95afddd4cd77367df1cfc511ad3b5c39f0d6dff9a", size = 2999640, upload-time = "2025-02-03T12:33:53.365Z" },
-    { url = "https://files.pythonhosted.org/packages/55/2a/417c7f661943ae93640c783075c59e7e405f912824d6d5a1c82dd3492198/psycopg2_yugabytedb_binary-2.9.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:9e63c5521e7d7226f0b582ff7afbd6760490239174327ea36df29705b5b338b7", size = 1721101, upload-time = "2025-01-31T11:59:12.538Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6d/5cb9dc723a5db1998201d2b9accdaf296b6d173f6c6994856a3084346b97/psycopg2_yugabytedb_binary-2.9.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71c6aca809599949d8ec5ff5a605c53de0cce720ec5fb9dcd79795530f361272", size = 2998392, upload-time = "2025-02-03T12:34:12.374Z" },
-]
-
-[[package]]
 name = "pyarrow"
 version = "21.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3923,9 +3827,6 @@ spanner = [
 valkey = [
     { name = "valkey" },
 ]
-yugabyte = [
-    { name = "psycopg2-yugabytedb" },
-]
 
 [package.dev-dependencies]
 build = [
@@ -3945,8 +3846,6 @@ dev = [
     { name = "pre-commit", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary", "pool"], marker = "python_full_version < '3.10'" },
     { name = "psycopg", version = "3.3.3", source = { registry = "https://pypi.org/simple" }, extra = ["binary", "pool"], marker = "python_full_version >= '3.10'" },
-    { name = "psycopg2-binary" },
-    { name = "psycopg2-yugabytedb-binary" },
     { name = "pyright" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -4027,8 +3926,6 @@ doc = [
 extra = [
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary", "pool"], marker = "python_full_version < '3.10'" },
     { name = "psycopg", version = "3.3.3", source = { registry = "https://pypi.org/simple" }, extra = ["binary", "pool"], marker = "python_full_version >= '3.10'" },
-    { name = "psycopg2-binary" },
-    { name = "psycopg2-yugabytedb-binary" },
 ]
 lint = [
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -4078,7 +3975,6 @@ requires-dist = [
     { name = "oracledb", marker = "extra == 'oracle'" },
     { name = "psycopg", marker = "extra == 'cockroachdb'" },
     { name = "psycopg", marker = "extra == 'postgres'", specifier = ">=3" },
-    { name = "psycopg2-yugabytedb", marker = "extra == 'yugabyte'" },
     { name = "pyarrow", marker = "extra == 'gizmosql'" },
     { name = "pymongo", marker = "extra == 'mongodb'" },
     { name = "pymssql", marker = "extra == 'mssql'" },
@@ -4100,8 +3996,6 @@ dev = [
     { name = "myst-parser" },
     { name = "pre-commit" },
     { name = "psycopg", extras = ["binary", "pool"] },
-    { name = "psycopg2-binary" },
-    { name = "psycopg2-yugabytedb-binary" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cdist", specifier = ">=0.2" },
@@ -4150,11 +4044,7 @@ doc = [
     { name = "sphinx-toolbox", specifier = ">=3.8.1" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
 ]
-extra = [
-    { name = "psycopg", extras = ["binary", "pool"] },
-    { name = "psycopg2-binary" },
-    { name = "psycopg2-yugabytedb-binary" },
-]
+extra = [{ name = "psycopg", extras = ["binary", "pool"] }]
 lint = [
     { name = "mypy" },
     { name = "pre-commit" },


### PR DESCRIPTION
## Summary
- remove built-in MySQL connection fixtures and validate services with the container CLI
- add fixture-level user/password/database config for service setup
- keep the MySQL optional dependency group available as an empty compatibility extra
- remove mysql-connector-python from test dependencies and lockfile
- update MySQL docs to describe clientless service fixtures

## Validation
- uv run ruff check src/pytest_databases/docker/mysql.py tests/test_mysql.py
- uv run pyright src/pytest_databases/docker/mysql.py tests/test_mysql.py
- uv run mypy src/pytest_databases/docker/mysql.py tests/test_mysql.py
- uv run pytest tests/test_mysql.py