### PR TITLE
fix(dolt): refetch container in setup retry loop

### DIFF
--- a/src/pytest_databases/docker/dolt.py
+++ b/src/pytest_databases/docker/dolt.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
+from docker.errors import APIError, NotFound
 
 from pytest_databases.helpers import get_xdist_worker_num
 from pytest_databases.types import ServiceContainer, XdistIsolationLevel
@@ -104,26 +105,40 @@ def _provide_dolt_service(
         transient=isolation_level == "server",
         platform=platform,
     ) as service:
-        # Final setup: ensure the worker-specific database exists and permissions are correct
+        # Ensure the worker-specific database exists and permissions are correct.
+        # Grant global privileges to the app user so tests can create databases
+        # if needed, matching the MySQL/MariaDB pattern.
         container_name = f"pytest_databases_{name}"
-        container = docker_service._get_container(container_name)
-        if container:
-            # Dolt SQL setup for database and user permissions
-            # We grant global privileges to the app user so they can create databases in tests if needed,
-            # matching the MySQL/MariaDB pattern.
-            setup_sql = (
-                f"CREATE DATABASE IF NOT EXISTS {db_name}; "
-                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; "
-                "FLUSH PRIVILEGES;"
-            )
-            # Retry setup a few times if it fails
-            for _ in range(5):
-                res = container.exec_run(
-                    ["dolt", "sql", "-q", setup_sql],
-                )
-                if res.exit_code == 0:
-                    break
+        setup_sql = (
+            f"CREATE DATABASE IF NOT EXISTS {db_name}; GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; FLUSH PRIVILEGES;"
+        )
+        # Refetch the container on each attempt: with transient containers under
+        # parallel xdist, the post-readiness window can race with auto-remove and
+        # a handle cached above the loop would 404 on every retry.
+        last_error: str | None = None
+        for attempt in range(5):
+            container = docker_service._get_container(container_name)
+            if container is None:
+                last_error = "container not found"
+            else:
+                try:
+                    res = container.exec_run(["dolt", "sql", "-q", setup_sql])
+                except NotFound:
+                    last_error = "container removed mid-exec"
+                except APIError as exc:
+                    if exc.status_code not in {404, 409}:
+                        raise
+                    last_error = f"docker api {exc.status_code}"
+                else:
+                    if res.exit_code == 0:
+                        break
+                    raw = res.output if isinstance(res.output, bytes) else b""
+                    last_error = f"exit {res.exit_code}: {raw.decode(errors='replace').strip()}"
+            if attempt < 4:
                 time.sleep(1)
+        else:
+            msg = f"Dolt setup SQL failed after 5 attempts: {last_error}"
+            raise RuntimeError(msg)
 
         yield DoltService(
             host=service.host,


### PR DESCRIPTION
## Summary

`_provide_dolt_service` cached a container handle from `_get_container` above its retry loop. Under parallel xdist with `transient=True`, `docker_service.run` returns success but the container can be auto-removed (Docker `remove=True` plus a brief Dolt startup blip) between the readiness check passing and the post-`run` setup `exec_run`. Every retry then 404s against the same stale ID and the fixture silently yields a broken service, surfacing later as `docker.errors.NotFound` at test setup.

This recurring flake has hit \`tests/test_dolt.py::test_xdist_isolate_server\` on the open clientless PRs (e.g. valkey #138 Python 3.11 - 1/3).

## Changes

- Refetch the container by name inside the loop so a fresh handle is used each iteration.
- Tolerate \`docker.errors.NotFound\` and 404/409 \`APIError\` from \`exec_run\` so a vanished container re-tries cleanly instead of bubbling up.
- Replace the previous silent-skip-on-missing-container path with an explicit \`RuntimeError\` after 5 attempts: a genuinely dead container should fail fixture setup loudly instead of producing a half-baked \`DoltService\`.

## Test plan
- [x] \`uv run pytest tests/test_dolt.py -v\` — all 3 tests pass locally including the previously flaky \`test_xdist_isolate_server\`.
- [x] \`uv run ruff check src/pytest_databases/docker/dolt.py\`
- [x] \`uv run mypy src/pytest_databases/docker/dolt.py\`
- [x] \`uv run pyright src/pytest_databases/docker/dolt.py\`
- [x] CI green across the full Python matrix.