### PR TITLE
feat: move Spanner to clientless validation

### DIFF
--- a/docs/supported-databases/spanner.rst
+++ b/docs/supported-databases/spanner.rst
@@ -1,36 +1,40 @@
 Spanner
 =======
 
-Integration with `Google Cloud Spanner <https://cloud.google.com/spanner>`_ using the `Spanner Emulator <https://cloud.google.com/spanner/docs/emulator>`_
-
-This integration uses the official `Google Cloud Spanner Python Client <https://cloud.google.com/python/docs/reference/spanner/latest>`_ for testing against the Spanner Emulator. The emulator provides a local development environment that mimics the behavior of Cloud Spanner, allowing you to test your application without connecting to the actual service.
+Integration with `Google Cloud Spanner <https://cloud.google.com/spanner>`_ using the `Spanner Emulator <https://cloud.google.com/spanner/docs/emulator>`_.
 
 Installation
 ------------
 
 .. code-block:: bash
 
-   pip install pytest-databases[spanner]
+   pip install pytest-databases
+
+Bring your own client (for example ``google-cloud-spanner``).
 
 Usage Example
 -------------
 
 .. code-block:: python
 
-    import pytest
-    from google.cloud import spanner
     import contextlib
+
+    from google.api_core.client_options import ClientOptions
+    from google.auth.credentials import AnonymousCredentials
+    from google.cloud import spanner
+
     from pytest_databases.docker.spanner import SpannerService
 
     pytest_plugins = ["pytest_databases.docker.spanner"]
 
+
     def test(spanner_service: SpannerService) -> None:
-        spanner_client = spanner.Client(
+        client = spanner.Client(
             project=spanner_service.project,
-            credentials=spanner_service.credentials,
-            client_options=spanner_service.client_options,
+            credentials=AnonymousCredentials(),
+            client_options=ClientOptions(api_endpoint=spanner_service.endpoint),
         )
-        instance = spanner_client.instance(spanner_service.instance_name)
+        instance = client.instance(spanner_service.instance_name)
         with contextlib.suppress(Exception):
             instance.create()
 
@@ -39,18 +43,14 @@ Usage Example
             database.create()
 
         with database.snapshot() as snapshot:
-            resp = next(iter(snapshot.execute_sql("SELECT 1")))
-        assert resp[0] == 1
-
-    def test(spanner_connection: spanner.Client) -> None:
-        assert isinstance(spanner_connection, spanner.Client)
+            row = next(iter(snapshot.execute_sql("SELECT 1")))
+        assert row[0] == 1
 
 Available Fixtures
 ------------------
 
 * ``spanner_image``: The Docker image to use for Spanner.
 * ``spanner_service``: A fixture that provides a Spanner service.
-* ``spanner_connection``: A fixture that provides a Spanner connection.
 
 Service API
 -----------

--- a/docs/supported-databases/spanner.rst
+++ b/docs/supported-databases/spanner.rst
@@ -17,8 +17,6 @@ Usage Example
 
 .. code-block:: python
 
-    import contextlib
-
     from google.api_core.client_options import ClientOptions
     from google.auth.credentials import AnonymousCredentials
     from google.cloud import spanner
@@ -35,16 +33,13 @@ Usage Example
             client_options=ClientOptions(api_endpoint=spanner_service.endpoint),
         )
         instance = client.instance(spanner_service.instance_name)
-        with contextlib.suppress(Exception):
-            instance.create()
-
         database = instance.database(spanner_service.database_name)
-        with contextlib.suppress(Exception):
-            database.create()
 
         with database.snapshot() as snapshot:
             row = next(iter(snapshot.execute_sql("SELECT 1")))
         assert row[0] == 1
+
+The default instance and database are created automatically and ready to use.
 
 Available Fixtures
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ mysql = []
 oracle = []
 postgres = ["psycopg>=3"]
 redis = ["redis"]
-spanner = ["google-cloud-spanner"]
+spanner = []
 valkey = []
 yugabyte = []
 
@@ -121,6 +121,7 @@ lint = [
 ]
 test = [
   "coverage[toml]>=6.2",
+  "google-cloud-spanner",
   "pytest",
   "pytest-cov",
   "pytest-cdist>=0.2",
@@ -190,10 +191,6 @@ pretty = true
 show_column_numbers = true
 warn_no_return = false
 warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-disable_error_code = "attr-defined"
-module = "pytest_databases.docker.spanner"
 
 [[tool.mypy.overrides]]
 disable_error_code = "attr-defined"

--- a/src/pytest_databases/docker/spanner.py
+++ b/src/pytest_databases/docker/spanner.py
@@ -4,9 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
-from google.api_core.client_options import ClientOptions
-from google.auth.credentials import AnonymousCredentials, Credentials
-from google.cloud import spanner
 
 from pytest_databases.helpers import get_xdist_worker_num
 from pytest_databases.types import ServiceContainer
@@ -24,7 +21,6 @@ def spanner_image() -> str:
 
 @dataclass
 class SpannerService(ServiceContainer):
-    credentials: Credentials
     project: str
     database_name: str
     instance_name: str
@@ -32,10 +28,6 @@ class SpannerService(ServiceContainer):
     @property
     def endpoint(self) -> str:
         return f"{self.host}:{self.port}"
-
-    @property
-    def client_options(self) -> ClientOptions:
-        return ClientOptions(api_endpoint=self.endpoint)
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -51,23 +43,7 @@ def spanner_service(docker_service: DockerService, spanner_image: str) -> Genera
             host=service.host,
             port=service.port,
             container=service.container,
-            credentials=AnonymousCredentials(),
             project="emulator-test-project",
             instance_name="emulator-test-instance",
             database_name="emulator-test-database",
         )
-
-
-@pytest.fixture(autouse=False, scope="session")
-def spanner_connection(
-    spanner_service: SpannerService,
-) -> Generator[spanner.Client, None, None]:
-    client = spanner.Client(
-        project=spanner_service.project,
-        credentials=spanner_service.credentials,
-        client_options=spanner_service.client_options,
-    )
-    try:
-        yield client
-    finally:
-        client.close()

--- a/src/pytest_databases/docker/spanner.py
+++ b/src/pytest_databases/docker/spanner.py
@@ -11,7 +11,42 @@ from pytest_databases.types import ServiceContainer
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from docker.models.containers import Container
+
     from pytest_databases._service import DockerService
+
+
+SPANNER_GCLOUD_CLI_IMAGE = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+
+_SPANNER_BOOTSTRAP_SCRIPT = """\
+set -euo pipefail
+gcloud config configurations create emulator --quiet 2>/dev/null \
+    || gcloud config configurations activate emulator --quiet
+gcloud config set auth/disable_credentials true --quiet
+gcloud config set project "$PROJECT" --quiet
+gcloud config set api_endpoint_overrides/spanner http://localhost:9020/ --quiet
+gcloud spanner instances describe "$INSTANCE" --quiet >/dev/null 2>&1 \
+    || gcloud spanner instances create "$INSTANCE" --config=emulator-config --description=pytest-databases --nodes=1 --quiet
+gcloud spanner databases describe "$DATABASE" --instance="$INSTANCE" --quiet >/dev/null 2>&1 \
+    || gcloud spanner databases create "$DATABASE" --instance="$INSTANCE" --quiet
+"""
+
+
+def _bootstrap_spanner_emulator(
+    docker_service: DockerService,
+    emulator_container: Container,
+    *,
+    project: str,
+    instance_name: str,
+    database_name: str,
+) -> None:
+    docker_service._client.containers.run(
+        SPANNER_GCLOUD_CLI_IMAGE,
+        entrypoint=["bash", "-c", _SPANNER_BOOTSTRAP_SCRIPT],
+        environment={"PROJECT": project, "INSTANCE": instance_name, "DATABASE": database_name},
+        network_mode=f"container:{emulator_container.id}",
+        remove=True,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -32,6 +67,9 @@ class SpannerService(ServiceContainer):
 
 @pytest.fixture(autouse=False, scope="session")
 def spanner_service(docker_service: DockerService, spanner_image: str) -> Generator[SpannerService, None, None]:
+    project = "emulator-test-project"
+    instance_name = "emulator-test-instance"
+    database_name = "emulator-test-database"
     with docker_service.run(
         image=spanner_image,
         name=f"pytest_databases_spanner_{get_xdist_worker_num() or 0}",
@@ -39,11 +77,18 @@ def spanner_service(docker_service: DockerService, spanner_image: str) -> Genera
         wait_for_log="gRPC server listening at",
         transient=True,
     ) as service:
+        _bootstrap_spanner_emulator(
+            docker_service,
+            service.container,
+            project=project,
+            instance_name=instance_name,
+            database_name=database_name,
+        )
         yield SpannerService(
             host=service.host,
             port=service.port,
             container=service.container,
-            project="emulator-test-project",
-            instance_name="emulator-test-instance",
-            database_name="emulator-test-database",
+            project=project,
+            instance_name=instance_name,
+            database_name=database_name,
         )

--- a/tests/test_spanner.py
+++ b/tests/test_spanner.py
@@ -6,18 +6,47 @@ if TYPE_CHECKING:
     import pytest
 
 
+def test_plugin_imports_without_google_cloud_spanner(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import builtins
+
+    def test_import() -> None:
+        original_import = builtins.__import__
+        blocked = {"google.cloud.spanner", "google.api_core.client_options", "google.auth.credentials"}
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name in blocked:
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+        try:
+            import pytest_databases.docker.spanner
+        finally:
+            builtins.__import__ = original_import
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
 def test_service_fixture(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
-    from google.cloud import spanner
     import contextlib
+
+    from google.api_core.client_options import ClientOptions
+    from google.auth.credentials import AnonymousCredentials
+    from google.cloud import spanner
 
     pytest_plugins = ["pytest_databases.docker.spanner"]
 
     def test_spanner_service(spanner_service) -> None:
+        assert spanner_service.endpoint == f"{spanner_service.host}:{spanner_service.port}"
+
         spanner_client = spanner.Client(
             project=spanner_service.project,
-            credentials=spanner_service.credentials,
-            client_options=spanner_service.client_options,
+            credentials=AnonymousCredentials(),
+            client_options=ClientOptions(api_endpoint=spanner_service.endpoint),
         )
         instance = spanner_client.instance(spanner_service.instance_name)
         with contextlib.suppress(Exception):
@@ -33,17 +62,4 @@ def test_service_fixture(pytester: pytest.Pytester) -> None:
     """)
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
-    result.assert_outcomes(passed=1)
-
-
-def test_spanner_connection(pytester: pytest.Pytester) -> None:
-    pytester.makepyfile("""
-    from google.cloud import spanner
-    pytest_plugins = ["pytest_databases.docker.spanner"]
-
-    def test(spanner_connection) -> None:
-        assert isinstance(spanner_connection, spanner.Client)
-    """)
-
-    result = pytester.runpytest_subprocess("-p", "pytest_databases")
     result.assert_outcomes(passed=1)

--- a/tests/test_spanner.py
+++ b/tests/test_spanner.py
@@ -32,8 +32,6 @@ def test_plugin_imports_without_google_cloud_spanner(pytester: pytest.Pytester) 
 
 def test_service_fixture(pytester: pytest.Pytester) -> None:
     pytester.makepyfile("""
-    import contextlib
-
     from google.api_core.client_options import ClientOptions
     from google.auth.credentials import AnonymousCredentials
     from google.cloud import spanner
@@ -49,12 +47,7 @@ def test_service_fixture(pytester: pytest.Pytester) -> None:
             client_options=ClientOptions(api_endpoint=spanner_service.endpoint),
         )
         instance = spanner_client.instance(spanner_service.instance_name)
-        with contextlib.suppress(Exception):
-            instance.create()
-
         database = instance.database(spanner_service.database_name)
-        with contextlib.suppress(Exception):
-            database.create()
 
         with database.snapshot() as snapshot:
             resp = next(iter(snapshot.execute_sql("SELECT 1")))

--- a/uv.lock
+++ b/uv.lock
@@ -3794,9 +3794,6 @@ redis = [
     { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "redis", version = "7.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-spanner = [
-    { name = "google-cloud-spanner" },
-]
 
 [package.dev-dependencies]
 build = [
@@ -3807,6 +3804,7 @@ dev = [
     { name = "bump-my-version" },
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "google-cloud-spanner" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -3921,6 +3919,7 @@ lint = [
 test = [
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "google-cloud-spanner" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cdist", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -3939,7 +3938,6 @@ requires-dist = [
     { name = "docker" },
     { name = "filelock" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'" },
-    { name = "google-cloud-spanner", marker = "extra == 'spanner'" },
     { name = "psycopg", marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pyarrow", marker = "extra == 'gizmosql'" },
     { name = "pytest" },
@@ -3955,6 +3953,7 @@ dev = [
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "bump-my-version" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
+    { name = "google-cloud-spanner" },
     { name = "mypy" },
     { name = "myst-parser" },
     { name = "pre-commit" },
@@ -4024,6 +4023,7 @@ lint = [
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = ">=6.2" },
+    { name = "google-cloud-spanner" },
     { name = "pytest" },
     { name = "pytest-cdist", specifier = ">=0.2" },
     { name = "pytest-click" },


### PR DESCRIPTION
Drop `google-cloud-spanner` from the `spanner` extra. The plugin no longer imports a Google client; users construct their own `spanner.Client(...)` from the service metadata.

The fixture auto-creates the default instance and database before yielding, using a one-shot `gcr.io/google.com/cloudsdktool/cloud-sdk:slim` sidecar that shares the emulator's network namespace to reach the REST gateway on `localhost:9020`. The create step is idempotent so reused containers don't fail.

`SpannerService` loses its `credentials` and `client_options` fields; `endpoint` returns the gRPC `host:port`. The `spanner_connection` fixture is gone.

`google-cloud-spanner` moves to the `test` dependency group so the in-repo SQL regression still drives the emulator end-to-end.
