### PR TITLE
feat: add clientless Redpanda service

### DIFF
--- a/.github/ci/provider-groups.json
+++ b/.github/ci/provider-groups.json
@@ -41,6 +41,7 @@
     "tests/test_elasticsearch.py::test_plugin_imports_without_elasticsearch_clients",
     "tests/test_mongodb.py::test_plugin_imports_without_pymongo",
     "tests/test_mssql.py::test_plugin_imports_without_pymssql",
+    "tests/test_redpanda.py::test_plugin_imports_without_kafka_clients",
     "tests/test_spanner.py::test_plugin_imports_without_google_cloud_spanner",
     "tests/test_valkey.py::test_plugin_imports_without_valkey"
   ],
@@ -161,6 +162,12 @@
         "postgres:18"
       ],
       "docs_globs": ["docs/supported-databases/postgres.rst"]
+    },
+    "redpanda": {
+      "source_globs": ["src/pytest_databases/docker/redpanda.py"],
+      "test_paths": ["tests/test_redpanda.py"],
+      "images": ["docker.redpanda.com/redpandadata/redpanda:v26.1.13"],
+      "docs_globs": ["docs/supported-databases/redpanda.rst"]
     },
     "redis": {
       "source_globs": ["src/pytest_databases/docker/redis.py"],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Next
 Added
 ~~~~~
 
+* A clientless ``redpanda_service`` fixture with host-reachable advertised
+  broker metadata and xdist topic or server isolation.
 * First-class Docker and Podman runtime selection through one Docker-compatible API transport. Closes
   `gh-146 <https://github.com/litestar-org/pytest-databases/issues/146>`_.
 * Runtime-neutral ``container_client``, ``container_service``, and ``ContainerService`` names while retaining all

--- a/docs/supported-databases/index.rst
+++ b/docs/supported-databases/index.rst
@@ -18,6 +18,7 @@ This section provides detailed information on the supported databases, including
    yugabyte
    mongodb
    gizmosql
+   redpanda
    redis
    valkey
    elasticsearch

--- a/docs/supported-databases/redpanda.rst
+++ b/docs/supported-databases/redpanda.rst
@@ -1,0 +1,113 @@
+Redpanda
+========
+
+Integration with `Redpanda <https://www.redpanda.com/>`_, a Kafka-compatible
+streaming data platform. The fixture starts a single development broker and
+does not install or import a Python Kafka client.
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install pytest-databases
+
+Install the Kafka client used by your application separately if your tests need
+one. The service fixture itself remains clientless and uses the image's ``rpk``
+command for startup and health checks.
+
+Docker Image
+------------
+
+The default is the pinned official image
+``docker.redpanda.com/redpandadata/redpanda:v26.1.13``. The fixture works with
+both Docker and Podman through the selected container runtime. See
+:doc:`../getting-started/container-runtimes`.
+
+Configuration
+-------------
+
+* ``REDPANDA_IMAGE``: image override (default:
+  ``docker.redpanda.com/redpandadata/redpanda:v26.1.13``).
+* ``REDPANDA_PORT``: optional fixed host port. By default the container runtime
+  allocates a free port.
+* ``xdist_redpanda_isolation_level``: xdist isolation level (default:
+  ``database``).
+
+Usage Example
+-------------
+
+``RedpandaService.bootstrap_servers`` is the host-reachable Kafka endpoint to
+pass to your application's Kafka client. ``topic_prefix`` is unique to the
+xdist worker when logical isolation is active.
+
+The following smoke test stays clientless by running ``rpk`` in the service
+container:
+
+.. code-block:: python
+
+   from pytest_databases.docker.redpanda import RedpandaService
+
+   pytest_plugins = ["pytest_databases.docker.redpanda"]
+
+
+   def test_redpanda(redpanda_service: RedpandaService) -> None:
+       topic = f"{redpanda_service.topic_prefix}events"
+       result = redpanda_service.container.exec_run(
+           [
+               "rpk",
+               "topic",
+               "create",
+               topic,
+               "-X",
+               "brokers=127.0.0.1:9092",
+           ]
+       )
+       assert result.exit_code == 0
+       assert redpanda_service.bootstrap_servers == (
+           f"{redpanda_service.host}:{redpanda_service.port}"
+       )
+
+Parallel Testing (xdist)
+------------------------
+
+The default ``database`` isolation reuses one broker and gives each worker a
+topic prefix such as ``pytest_databases_gw0_``. Tests must apply
+``redpanda_service.topic_prefix`` to every topic they create.
+
+Override the fixture with ``"server"`` when each worker needs a separate
+broker:
+
+.. code-block:: python
+
+   import pytest
+
+
+   @pytest.fixture(scope="session")
+   def xdist_redpanda_isolation_level():
+       return "server"
+
+Server isolation starts one transient container per worker and returns an empty
+topic prefix.
+
+Available Fixtures
+------------------
+
+* ``redpanda_image``: the Redpanda image reference.
+* ``redpanda_port``: the optional fixed host port.
+* ``redpanda_service``: a running broker with ``bootstrap_servers`` and
+  ``topic_prefix`` metadata.
+* ``xdist_redpanda_isolation_level``: ``database`` or ``server`` isolation.
+
+.. note::
+
+   This fixture intentionally exposes Redpanda by name. It does not provide a
+   ``kafka_service`` alias or claim complete Apache Kafka compatibility.
+
+Service API
+-----------
+
+.. automodule:: pytest_databases.docker.redpanda
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/pytest_databases/docker/redpanda.py
+++ b/src/pytest_databases/docker/redpanda.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+from docker.errors import ContainerError
+
+from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer, XdistIsolationLevel
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_databases._service import ContainerService
+
+
+DEFAULT_REDPANDA_IMAGE = "docker.redpanda.com/redpandadata/redpanda:v26.1.13"
+REDPANDA_INTERNAL_PORT = 9092
+REDPANDA_EXTERNAL_PORT = 19092
+REDPANDA_PORT_FILE = "/var/lib/redpanda/data/.pytest-databases-host-port"
+
+
+@dataclass
+class RedpandaService(ServiceContainer):
+    """Metadata for a Kafka-compatible Redpanda broker."""
+
+    bootstrap_servers: str
+    topic_prefix: str
+
+
+def _redpanda_command() -> list[str]:
+    """Delay broker startup until the mapped host port can be advertised."""
+    script = "\n".join([
+        "set -eu",
+        f'while [ ! -s "{REDPANDA_PORT_FILE}" ]; do sleep 0.1; done',
+        f'advertised_port="$(cat {REDPANDA_PORT_FILE})"',
+        "exec rpk redpanda start \\",
+        "  --mode dev-container \\",
+        "  --smp 1 \\",
+        f"  --kafka-addr internal://0.0.0.0:{REDPANDA_INTERNAL_PORT},external://0.0.0.0:{REDPANDA_EXTERNAL_PORT} \\",
+        (
+            f"  --advertise-kafka-addr internal://127.0.0.1:{REDPANDA_INTERNAL_PORT},"
+            "external://127.0.0.1:${advertised_port} \\"
+        ),
+        "  --default-log-level=info",
+    ])
+    return ["-c", script]
+
+
+def _output_to_bytes(output: object) -> bytes:
+    if isinstance(output, bytes):
+        return output
+    if isinstance(output, str):
+        return output.encode()
+    return str(output).encode()
+
+
+@pytest.fixture(scope="session")
+def redpanda_image() -> str:
+    """Return the pinned Redpanda image, optionally overridden by the environment."""
+    return os.environ.get("REDPANDA_IMAGE", DEFAULT_REDPANDA_IMAGE)
+
+
+@pytest.fixture(scope="session")
+def redpanda_port() -> int | None:
+    """Return an optional host port override for the external Kafka listener."""
+    value = os.environ.get("REDPANDA_PORT")
+    return int(value) if value else None
+
+
+@pytest.fixture(scope="session")
+def xdist_redpanda_isolation_level() -> XdistIsolationLevel:
+    """Share one broker with worker topic prefixes by default."""
+    return "database"
+
+
+@pytest.fixture(scope="session")
+def redpanda_service(
+    container_service: ContainerService,
+    redpanda_image: str,
+    redpanda_port: int | None,
+    xdist_redpanda_isolation_level: XdistIsolationLevel,
+) -> Generator[RedpandaService, None, None]:
+    """Start a clientless Redpanda service with reachable advertised metadata.
+
+    Yields:
+        Service metadata for the running Redpanda broker.
+    """
+    worker_num = get_xdist_worker_num()
+    name = "redpanda"
+    topic_prefix = "pytest_databases_"
+    transient = False
+    if worker_num is not None:
+        if xdist_redpanda_isolation_level == "server":
+            name = f"{name}_{worker_num}"
+            topic_prefix = ""
+            transient = True
+        else:
+            topic_prefix = f"pytest_databases_{worker_num}_"
+
+    port_injected = False
+    ready = False
+    attempts = 0
+    last_output = b"Redpanda readiness was not attempted"
+
+    def check(service: ServiceContainer) -> bool:
+        nonlocal attempts, last_output, port_injected, ready
+        attempts += 1
+        if not port_injected:
+            result = service.container.exec_run([
+                "sh",
+                "-c",
+                f"printf '%s' {service.port} > {REDPANDA_PORT_FILE}",
+            ])
+            last_output = _output_to_bytes(result.output)
+            if result.exit_code != 0:
+                return False
+            port_injected = True
+
+        health = service.container.exec_run([
+            "sh",
+            "-c",
+            (f"timeout 5 rpk cluster health --exit-when-healthy -X brokers=127.0.0.1:{REDPANDA_INTERNAL_PORT}"),
+        ])
+        last_output = _output_to_bytes(health.output)
+        if health.exit_code != 0:
+            if attempts >= 20:
+                message = f"Redpanda rpk readiness failed: {last_output.decode(errors='replace').strip()}"
+                raise RuntimeError(message)
+            return False
+
+        if not ready:
+            bootstrap_servers = f"{service.host}:{service.port}"
+            try:
+                external_info = container_service.run_container(
+                    redpanda_image,
+                    service_name=f"{name}-external-readiness",
+                    entrypoint=["rpk"],
+                    command=["cluster", "info", "-X", f"brokers={bootstrap_servers}"],
+                    network_mode="host",
+                    remove=True,
+                )
+            except ContainerError as error:
+                last_output = _output_to_bytes(error.stderr or str(error))
+                return False
+            last_output = _output_to_bytes(external_info)
+            expected_host, _, expected_port = bootstrap_servers.partition(":")
+            if expected_host.encode() not in last_output or expected_port.encode() not in last_output:
+                if attempts >= 20:
+                    message = (
+                        "Redpanda metadata did not advertise the mapped endpoint: "
+                        f"{last_output.decode(errors='replace').strip()}"
+                    )
+                    raise RuntimeError(message)
+                return False
+            ready = True
+        return True
+
+    with container_service.run(
+        image=redpanda_image,
+        container_port=REDPANDA_EXTERNAL_PORT,
+        name=name,
+        command=_redpanda_command(),
+        entrypoint=["/bin/sh"],
+        check=check,
+        timeout=120,
+        pause=0.5,
+        transient=transient,
+        host_port=redpanda_port,
+    ) as service:
+        yield RedpandaService(
+            container=service.container,
+            host=service.host,
+            port=service.port,
+            bootstrap_servers=f"{service.host}:{service.port}",
+            topic_prefix=topic_prefix,
+        )

--- a/tests/test_redpanda.py
+++ b/tests/test_redpanda.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+
+from pytest_databases.docker import redpanda
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+REDPANDA_TEST_HELPERS = r"""
+def rpk(service, *args):
+    result = service.container.exec_run([
+        "rpk",
+        *args,
+        "-X",
+        "brokers=127.0.0.1:9092",
+    ])
+    output = result.output if isinstance(result.output, bytes) else str(result.output).encode()
+    assert result.exit_code == 0, output.decode(errors="replace")
+    return output
+
+
+def round_trip(service, suffix):
+    topic = f"{service.topic_prefix}smoke_{suffix}"
+    rpk(service, "topic", "create", topic, "--partitions", "1", "--replicas", "1")
+    try:
+        produced = service.container.exec_run([
+            "sh",
+            "-c",
+            f"printf 'test-value\\n' | rpk topic produce {topic} --key test-key "
+            "-X brokers=127.0.0.1:9092",
+        ])
+        assert produced.exit_code == 0, produced.output
+        consumed = rpk(
+            service,
+            "topic",
+            "consume",
+            topic,
+            "--num",
+            "1",
+            "--offset",
+            "start",
+            "--format",
+            "%k|%v",
+        )
+        assert consumed.strip() == b"test-key|test-value"
+    finally:
+        rpk(service, "topic", "delete", topic)
+"""
+
+
+def test_plugin_imports_without_kafka_clients(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import builtins
+
+    def test_import() -> None:
+        original_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith(("confluent_kafka", "kafka")):
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+        try:
+            import pytest_databases.docker.redpanda  # noqa: F401
+        finally:
+            builtins.__import__ = original_import
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_public_contract_and_environment_overrides(monkeypatch: MonkeyPatch) -> None:
+    service = redpanda.RedpandaService(
+        container=Mock(),
+        host="127.0.0.1",
+        port=19092,
+        bootstrap_servers="127.0.0.1:19092",
+        topic_prefix="pytest_databases_",
+    )
+    assert service.bootstrap_servers == f"{service.host}:{service.port}"
+    assert service.topic_prefix == "pytest_databases_"
+
+    assert redpanda.redpanda_image.__wrapped__() == redpanda.DEFAULT_REDPANDA_IMAGE  # type: ignore[attr-defined]
+    assert redpanda.redpanda_port.__wrapped__() is None  # type: ignore[attr-defined]
+    monkeypatch.setenv("REDPANDA_IMAGE", "example.test/redpanda:v1")
+    monkeypatch.setenv("REDPANDA_PORT", "29092")
+    assert redpanda.redpanda_image.__wrapped__() == "example.test/redpanda:v1"  # type: ignore[attr-defined]
+    assert redpanda.redpanda_port.__wrapped__() == 29092  # type: ignore[attr-defined]
+
+
+def test_start_command_waits_for_the_mapped_port() -> None:
+    command = redpanda._redpanda_command()
+    assert command[0] == "-c"
+    assert redpanda.REDPANDA_PORT_FILE in command[1]
+    assert "external://0.0.0.0:19092" in command[1]
+    assert "external://127.0.0.1:${advertised_port}" in command[1]
+
+
+def test_default_service_is_clientless(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(f"""
+from pytest_databases.docker.redpanda import RedpandaService
+
+pytest_plugins = ["pytest_databases.docker.redpanda"]
+
+{REDPANDA_TEST_HELPERS}
+
+
+def test_round_trip(redpanda_service: RedpandaService):
+    assert redpanda_service.host == "127.0.0.1"
+    assert redpanda_service.bootstrap_servers == f"{{redpanda_service.host}}:{{redpanda_service.port}}"
+    assert redpanda_service.topic_prefix == "pytest_databases_"
+    round_trip(redpanda_service, "default")
+""")
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("isolation_level", ["database", "server"])
+def test_xdist_isolation_is_clientless(pytester: pytest.Pytester, isolation_level: str) -> None:
+    pytester.makepyfile(f"""
+import pytest
+
+from pytest_databases.docker.redpanda import RedpandaService
+from pytest_databases.helpers import get_xdist_worker_num
+
+pytest_plugins = ["pytest_databases.docker.redpanda"]
+
+
+@pytest.fixture(scope="session")
+def xdist_redpanda_isolation_level():
+    return "{isolation_level}"
+
+
+{REDPANDA_TEST_HELPERS}
+
+
+def assert_round_trip(service: RedpandaService):
+    worker = get_xdist_worker_num()
+    if "{isolation_level}" == "database":
+        assert service.topic_prefix == f"pytest_databases_{{worker}}_"
+    else:
+        assert service.topic_prefix == ""
+    round_trip(service, f"worker_{{worker}}")
+
+
+def test_one(redpanda_service: RedpandaService):
+    assert_round_trip(redpanda_service)
+
+
+def test_two(redpanda_service: RedpandaService):
+    assert_round_trip(redpanda_service)
+""")
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2", "-vv")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Summary\n\n- add a Redpanda service using the official container and bundled rpk CLI\n- support database and server xdist isolation with dynamic advertised ports\n- document the fixture and register one-provider selective CI ownership\n\n## Validation\n\n- provider tests: 6 passed\n- compatibility runner: 34 passed\n- Ruff, mypy, pyright, slotscheck, pre-commit, and docs passed\n- selector: 1 provider job, 1 image pull\n- no Python client dependency or lockfile change\n\nPart of #150.