### PR TITLE
feat: add clientless LocalStack service

### DIFF
--- a/.github/ci/provider-groups.json
+++ b/.github/ci/provider-groups.json
@@ -95,6 +95,12 @@
       "images": ["gizmodata/gizmosql:latest"],
       "docs_globs": ["docs/supported-databases/gizmosql.rst"]
     },
+    "localstack": {
+      "source_globs": ["src/pytest_databases/docker/localstack.py"],
+      "test_paths": ["tests/test_localstack.py"],
+      "images": ["localstack/localstack:4.14.0"],
+      "docs_globs": ["docs/supported-databases/localstack.rst"]
+    },
     "mariadb": {
       "source_globs": ["src/pytest_databases/docker/mariadb.py"],
       "test_paths": ["tests/test_mariadb.py"],

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Ready-made database fixtures for your pytest tests.
 - **Elasticsearch**: Version 7 and 8 are available
 - **Azure blob storage**: Via azurite
 - **Minio**: Latest version
+- **LocalStack**: Tokenless AWS service emulation with in-container CLI access
 
 ## Installation
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Next
 Added
 ~~~~~
 
+* A dependency-free ``localstack_service`` fixture with clientless SQS operations, worker-safe resource prefixes,
+  and Docker or Podman support. Closes `gh-150 <https://github.com/litestar-org/pytest-databases/issues/150>`_.
 * First-class Docker and Podman runtime selection through one Docker-compatible API transport. Closes
   `gh-146 <https://github.com/litestar-org/pytest-databases/issues/146>`_.
 * Runtime-neutral ``container_client``, ``container_service``, and ``ContainerService`` names while retaining all

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -7,6 +7,10 @@ First, install the base package using pip:
 
    pip install pytest-databases
 
+The base package includes LocalStack support. It uses the AWS CLI bundled in
+the LocalStack container, so it does not install ``boto3``, ``botocore``, or a
+host-side AWS CLI.
+
 Optional Database Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/supported-databases/index.rst
+++ b/docs/supported-databases/index.rst
@@ -18,6 +18,7 @@ This section provides detailed information on the supported databases, including
    yugabyte
    mongodb
    gizmosql
+   localstack
    redis
    valkey
    elasticsearch

--- a/docs/supported-databases/localstack.rst
+++ b/docs/supported-databases/localstack.rst
@@ -1,0 +1,111 @@
+LocalStack
+==========
+
+Integration with `LocalStack <https://www.localstack.cloud/>`_, an AWS service
+emulator. The fixture exposes the LocalStack gateway and can run AWS commands
+inside the service container. No Python AWS SDK or host-side AWS CLI is
+required.
+
+Installation
+------------
+
+LocalStack support is included in the base package:
+
+.. code-block:: bash
+
+   pip install pytest-databases
+
+Image and Authentication
+------------------------
+
+The default image is ``localstack/localstack:4.14.0``, the final tokenless
+Community release. This preserves an offline default that needs neither a
+LocalStack account nor cloud credentials. Current LocalStack releases require
+an auth token. To opt into one, set both ``LOCALSTACK_IMAGE`` and
+``LOCALSTACK_AUTH_TOKEN``.
+
+The image must provide ``awslocal`` or ``aws`` and ``curl``. The standard
+LocalStack image includes them. The fixture uses those in-container tools for
+readiness and AWS operations, and does not mount a container-engine socket.
+
+Configuration
+-------------
+
+* ``LOCALSTACK_IMAGE``: Image override (default: ``localstack/localstack:4.14.0``).
+* ``LOCALSTACK_AUTH_TOKEN``: Optional token for images that require one.
+* ``LOCALSTACK_REGION``: AWS region (default: ``us-east-1``).
+* ``LOCALSTACK_ACCESS_KEY``: Test access key (default: ``test``).
+* ``LOCALSTACK_SECRET_KEY``: Test secret key (default: ``test``).
+* ``LOCALSTACK_SERVICES``: Optional comma-separated service allowlist. Omitting
+  it leaves LocalStack's normal service set available.
+* ``LOCALSTACK_RESOURCE_PREFIX``: Resource-name prefix override. By default,
+  each xdist worker receives a distinct prefix.
+
+Usage Example
+-------------
+
+``exec_aws_cli()`` executes in the LocalStack container. This example creates,
+sends to, receives from, and deletes an SQS queue without importing an AWS
+client library:
+
+.. code-block:: python
+
+   import json
+
+   from pytest_databases.docker.localstack import LocalStackService
+
+   pytest_plugins = ["pytest_databases.docker.localstack"]
+
+
+   def test_sqs(localstack_service: LocalStackService) -> None:
+       queue_name = f"{localstack_service.resource_prefix}messages"
+       created = json.loads(
+           localstack_service.exec_aws_cli(
+               "sqs", "create-queue", "--queue-name", queue_name, "--output", "json"
+           )
+       )
+       queue_url = created["QueueUrl"]
+       localstack_service.exec_aws_cli(
+           "sqs", "send-message", "--queue-url", queue_url, "--message-body", "hello"
+       )
+       received = json.loads(
+           localstack_service.exec_aws_cli(
+               "sqs", "receive-message", "--queue-url", queue_url, "--output", "json"
+           )
+       )
+       message = received["Messages"][0]
+       assert message["Body"] == "hello"
+       localstack_service.exec_aws_cli(
+           "sqs",
+           "delete-message",
+           "--queue-url",
+           queue_url,
+           "--receipt-handle",
+           message["ReceiptHandle"],
+       )
+       localstack_service.exec_aws_cli("sqs", "delete-queue", "--queue-url", queue_url)
+
+Available Fixtures
+------------------
+
+* ``localstack_image``
+* ``localstack_auth_token``
+* ``localstack_region``
+* ``localstack_access_key``
+* ``localstack_secret_key``
+* ``localstack_services``
+* ``localstack_resource_prefix``
+* ``xdist_localstack_isolation_level``
+* ``localstack_service``
+
+The default xdist isolation level is ``database``: workers share a server and
+use unique resource prefixes. Override ``xdist_localstack_isolation_level`` to
+``server`` to start one transient LocalStack container per worker.
+
+Service API
+-----------
+
+.. automodule:: pytest_databases.docker.localstack
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/pytest_databases/docker/localstack.py
+++ b/src/pytest_databases/docker/localstack.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer, XdistIsolationLevel
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+
+    from docker.models.containers import Container
+
+    from pytest_databases._service import ContainerService
+
+
+_LOCALSTACK_GATEWAY_PORT = 4566
+_LOCALSTACK_CLI = """\
+if command -v awslocal >/dev/null 2>&1; then
+    exec awslocal --region "$AWS_DEFAULT_REGION" "$@"
+fi
+if command -v aws >/dev/null 2>&1; then
+    exec aws --endpoint-url=http://localhost:4566 --region "$AWS_DEFAULT_REGION" "$@"
+fi
+exit 127
+"""
+
+
+def _exec_aws_cli(container: Container, arguments: Sequence[str]) -> tuple[int, str]:
+    result = container.exec_run(["sh", "-c", _LOCALSTACK_CLI, "pytest-databases", *arguments])
+    output_bytes = result.output if isinstance(result.output, bytes) else b"".join(result.output)
+    output = output_bytes.decode("utf-8", errors="replace")
+    exit_code = result.exit_code
+    if exit_code is None:
+        msg = "LocalStack AWS CLI command did not return an exit code"
+        raise RuntimeError(msg)
+    if exit_code == 127:
+        msg = "LocalStack image must provide the awslocal or aws CLI"
+        raise RuntimeError(msg)
+    return exit_code, output
+
+
+def _health_is_ready(container: Container) -> bool:
+    result = container.exec_run([
+        "curl",
+        "--silent",
+        "--show-error",
+        "--fail",
+        "--dump-header",
+        "-",
+        "--output",
+        "/dev/null",
+        "http://localhost:4566/_localstack/health",
+    ])
+    exit_code = result.exit_code
+    if exit_code is None:
+        return False
+    if exit_code == 127:
+        msg = "LocalStack image must provide curl for its in-container health check"
+        raise RuntimeError(msg)
+    output = result.output if isinstance(result.output, bytes) else b"".join(result.output)
+    return exit_code == 0 and b"x-localstack:" in output.lower()
+
+
+@dataclass
+class LocalStackService(ServiceContainer):
+    endpoint_url: str
+    region: str
+    access_key: str
+    secret_key: str
+    services: tuple[str, ...] | None
+    resource_prefix: str
+
+    def exec_aws_cli(self, *arguments: str) -> str:
+        """Run an AWS command inside LocalStack without a host-side AWS client."""
+        exit_code, output = _exec_aws_cli(self.container, arguments)
+        if exit_code != 0:
+            command = " ".join(arguments)
+            msg = f"LocalStack AWS CLI command failed ({command}): {output.strip()}"
+            raise RuntimeError(msg)
+        return output
+
+
+@pytest.fixture(scope="session")
+def localstack_image() -> str:
+    # 4.14.0 is the final tokenless Community release. Newer images require a
+    # LocalStack account token and therefore cannot satisfy this fixture's
+    # offline-by-default contract.
+    return os.getenv("LOCALSTACK_IMAGE", "localstack/localstack:4.14.0")
+
+
+@pytest.fixture(scope="session")
+def localstack_auth_token() -> str | None:
+    """Return an optional token for users who explicitly select a newer image."""
+    return os.getenv("LOCALSTACK_AUTH_TOKEN")
+
+
+@pytest.fixture(scope="session")
+def localstack_region() -> str:
+    return os.getenv("LOCALSTACK_REGION", "us-east-1")
+
+
+@pytest.fixture(scope="session")
+def localstack_access_key() -> str:
+    return os.getenv("LOCALSTACK_ACCESS_KEY", "test")
+
+
+@pytest.fixture(scope="session")
+def localstack_secret_key() -> str:
+    return os.getenv("LOCALSTACK_SECRET_KEY", "test")
+
+
+@pytest.fixture(scope="session")
+def localstack_services() -> tuple[str, ...] | None:
+    value = os.getenv("LOCALSTACK_SERVICES")
+    if value is None:
+        return None
+    services = tuple(service.strip() for service in value.split(",") if service.strip())
+    return services or None
+
+
+@pytest.fixture(scope="session")
+def xdist_localstack_isolation_level() -> XdistIsolationLevel:
+    return "database"
+
+
+@pytest.fixture(scope="session")
+def localstack_resource_prefix() -> str:
+    if value := os.getenv("LOCALSTACK_RESOURCE_PREFIX"):
+        return value
+    worker_num = get_xdist_worker_num()
+    if worker_num is None:
+        return "pytest-databases-"
+    return f"pytest-databases-{worker_num}-"
+
+
+@pytest.fixture(scope="session")
+def localstack_service(
+    container_service: ContainerService,
+    localstack_image: str,
+    localstack_region: str,
+    localstack_access_key: str,
+    localstack_secret_key: str,
+    localstack_auth_token: str | None,
+    localstack_services: tuple[str, ...] | None,
+    localstack_resource_prefix: str,
+    xdist_localstack_isolation_level: XdistIsolationLevel,
+) -> Generator[LocalStackService, None, None]:
+    worker_num = get_xdist_worker_num()
+    name = "localstack"
+    transient = False
+    if worker_num is not None and xdist_localstack_isolation_level == "server":
+        name = f"{name}_{worker_num}"
+        transient = True
+
+    environment = {
+        "AWS_ACCESS_KEY_ID": localstack_access_key,
+        "AWS_DEFAULT_REGION": localstack_region,
+        "AWS_SECRET_ACCESS_KEY": localstack_secret_key,
+    }
+    if localstack_services is not None:
+        environment["SERVICES"] = ",".join(localstack_services)
+    if localstack_auth_token is not None:
+        environment["LOCALSTACK_AUTH_TOKEN"] = localstack_auth_token
+
+    def check(service: ServiceContainer) -> bool:
+        if not _health_is_ready(service.container):
+            return False
+        if localstack_services is not None and "sqs" not in localstack_services:
+            return True
+        exit_code, _ = _exec_aws_cli(service.container, ("sqs", "list-queues", "--output", "json"))
+        return exit_code == 0
+
+    with container_service.run(
+        image=localstack_image,
+        name=name,
+        container_port=_LOCALSTACK_GATEWAY_PORT,
+        env=environment,
+        check=check,
+        timeout=60,
+        pause=0.5,
+        transient=transient,
+    ) as service:
+        yield LocalStackService(
+            host=service.host,
+            port=service.port,
+            container=service.container,
+            endpoint_url=f"http://{service.host}:{service.port}",
+            region=localstack_region,
+            access_key=localstack_access_key,
+            secret_key=localstack_secret_key,
+            services=localstack_services,
+            resource_prefix=localstack_resource_prefix,
+        )

--- a/tests/test_localstack.py
+++ b/tests/test_localstack.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_plugin_imports_without_aws_clients(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import builtins
+
+    def test_import() -> None:
+        original_import = builtins.__import__
+        blocked = {"awscli", "boto3", "botocore", "localstack_client"}
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.partition(".")[0] in blocked:
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+        try:
+            import pytest_databases.docker.localstack
+        finally:
+            builtins.__import__ = original_import
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_sqs_lifecycle_uses_the_container_cli(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import json
+
+    from pytest_databases.docker.localstack import LocalStackService
+
+    pytest_plugins = ["pytest_databases.docker.localstack"]
+
+    def test(localstack_service: LocalStackService) -> None:
+        assert localstack_service.endpoint_url == f"http://{localstack_service.host}:{localstack_service.port}"
+        assert localstack_service.region == "us-east-1"
+        assert localstack_service.access_key == "test"
+        assert localstack_service.secret_key == "test"
+        assert localstack_service.services is None
+        assert localstack_service.resource_prefix.startswith("pytest-databases-")
+
+        queue_name = f"{localstack_service.resource_prefix}sqs-lifecycle"
+        created = json.loads(localstack_service.exec_aws_cli(
+            "sqs", "create-queue", "--queue-name", queue_name, "--output", "json"
+        ))
+        queue_url = created["QueueUrl"]
+        sent = json.loads(localstack_service.exec_aws_cli(
+            "sqs", "send-message", "--queue-url", queue_url,
+            "--message-body", "clientless", "--output", "json"
+        ))
+        assert sent["MessageId"]
+
+        received = json.loads(localstack_service.exec_aws_cli(
+            "sqs", "receive-message", "--queue-url", queue_url,
+            "--wait-time-seconds", "1", "--max-number-of-messages", "1", "--output", "json"
+        ))
+        message = received["Messages"][0]
+        assert message["Body"] == "clientless"
+        localstack_service.exec_aws_cli(
+            "sqs", "delete-message", "--queue-url", queue_url,
+            "--receipt-handle", message["ReceiptHandle"]
+        )
+        localstack_service.exec_aws_cli("sqs", "delete-queue", "--queue-url", queue_url)
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_fixture_overrides_are_visible(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import pytest
+
+    pytest_plugins = ["pytest_databases.docker.localstack"]
+
+    @pytest.fixture(scope="session")
+    def localstack_region():
+        return "eu-west-1"
+
+    @pytest.fixture(scope="session")
+    def localstack_access_key():
+        return "override-access"
+
+    @pytest.fixture(scope="session")
+    def localstack_secret_key():
+        return "override-secret"
+
+    @pytest.fixture(scope="session")
+    def localstack_services():
+        return ("s3",)
+
+    @pytest.fixture(scope="session")
+    def localstack_resource_prefix():
+        return "custom-prefix-"
+
+    def test(localstack_service) -> None:
+        assert localstack_service.region == "eu-west-1"
+        assert localstack_service.access_key == "override-access"
+        assert localstack_service.secret_key == "override-secret"
+        assert localstack_service.services == ("s3",)
+        assert localstack_service.resource_prefix == "custom-prefix-"
+        environment = localstack_service.container.attrs["Config"]["Env"]
+        assert "SERVICES=s3" in environment
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_xdist_database_isolation(
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("LOCALSTACK_TEST_STATE", str(tmp_path))
+    pytester.makepyfile("""
+    import os
+    from pathlib import Path
+
+    pytest_plugins = ["pytest_databases.docker.localstack"]
+
+    def record(localstack_service) -> None:
+        worker = os.environ["PYTEST_XDIST_WORKER"]
+        value = f"{localstack_service.container.id}|{localstack_service.resource_prefix}"
+        Path(os.environ["LOCALSTACK_TEST_STATE"], f"{worker}.txt").write_text(value, encoding="utf-8")
+
+    def test_one(localstack_service) -> None:
+        record(localstack_service)
+
+    def test_two(localstack_service) -> None:
+        record(localstack_service)
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2", "-vv")
+    result.assert_outcomes(passed=2)
+    records = [path.read_text(encoding="utf-8").split("|") for path in sorted(tmp_path.glob("gw*.txt"))]
+    assert len(records) == 2
+    assert len({container_id for container_id, _ in records}) == 1
+    assert len({prefix for _, prefix in records}) == 2
+
+
+def test_xdist_server_isolation(
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("LOCALSTACK_TEST_STATE", str(tmp_path))
+    pytester.makepyfile("""
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    pytest_plugins = ["pytest_databases.docker.localstack"]
+
+    @pytest.fixture(scope="session")
+    def xdist_localstack_isolation_level():
+        return "server"
+
+    def record(localstack_service) -> None:
+        worker = os.environ["PYTEST_XDIST_WORKER"]
+        Path(os.environ["LOCALSTACK_TEST_STATE"], f"{worker}.txt").write_text(
+            localstack_service.container.id, encoding="utf-8"
+        )
+
+    def test_one(localstack_service) -> None:
+        record(localstack_service)
+
+    def test_two(localstack_service) -> None:
+        record(localstack_service)
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2", "-vv")
+    result.assert_outcomes(passed=2)
+    container_ids = {path.read_text(encoding="utf-8") for path in tmp_path.glob("gw*.txt")}
+    assert len(container_ids) == 2


### PR DESCRIPTION
## Summary\n\n- add a LocalStack SQS service using awslocal or the bundled aws CLI inside the container\n- support shared worker prefixes and per-worker server isolation\n- document image overrides and register one-provider selective CI ownership\n\n## Validation\n\n- provider tests: 5 passed\n- Ruff, mypy, pyright, and docs passed\n- selector: 1 provider job, 1 image pull\n- no boto3, Python client dependency, or lockfile change\n\nPart of #150.