### PR TITLE
feat: add clientless Pub/Sub emulator service

### DIFF
--- a/.github/ci/provider-groups.json
+++ b/.github/ci/provider-groups.json
@@ -166,7 +166,9 @@
     "pubsub": {
       "source_globs": ["src/pytest_databases/docker/pubsub.py"],
       "test_paths": ["tests/test_pubsub.py"],
-      "images": ["gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"],
+      "images": [
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"
+      ],
       "docs_globs": ["docs/supported-databases/pubsub.rst"]
     },
     "redis": {

--- a/.github/ci/provider-groups.json
+++ b/.github/ci/provider-groups.json
@@ -41,6 +41,7 @@
     "tests/test_elasticsearch.py::test_plugin_imports_without_elasticsearch_clients",
     "tests/test_mongodb.py::test_plugin_imports_without_pymongo",
     "tests/test_mssql.py::test_plugin_imports_without_pymssql",
+    "tests/test_pubsub.py::test_plugin_imports_without_google_cloud_pubsub",
     "tests/test_spanner.py::test_plugin_imports_without_google_cloud_spanner",
     "tests/test_valkey.py::test_plugin_imports_without_valkey"
   ],
@@ -161,6 +162,12 @@
         "postgres:18"
       ],
       "docs_globs": ["docs/supported-databases/postgres.rst"]
+    },
+    "pubsub": {
+      "source_globs": ["src/pytest_databases/docker/pubsub.py"],
+      "test_paths": ["tests/test_pubsub.py"],
+      "images": ["gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"],
+      "docs_globs": ["docs/supported-databases/pubsub.rst"]
     },
     "redis": {
       "source_globs": ["src/pytest_databases/docker/redis.py"],

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Ready-made database fixtures for your pytest tests.
 - **Google AlloyDB Omni**: Simplified Omni installation for easy testing.
 - **Google Spanner**: The latest cloud-emulator from Google is available
 - **Google BigQuery**: Unofficial BigQuery emulator
+- **Google Pub/Sub**: Official Google Cloud Pub/Sub emulator
 - **CockroachDB**: Version latest is available
 - **Redis**: Latest version
 - **Valkey**: Latest version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Next
 Added
 ~~~~~
 
+* Clientless Google Pub/Sub emulator fixtures backed by the official Google Cloud CLI emulator image, with Docker and
+  Podman-compatible lifecycle management, project-scoped xdist isolation, and an in-container protocol smoke check.
 * First-class Docker and Podman runtime selection through one Docker-compatible API transport. Closes
   `gh-146 <https://github.com/litestar-org/pytest-databases/issues/146>`_.
 * Runtime-neutral ``container_client``, ``container_service``, and ``ContainerService`` names while retaining all

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -7,6 +7,9 @@ First, install the base package using pip:
 
    pip install pytest-databases
 
+Clientless service fixtures such as the Google Pub/Sub emulator are included in the base package. Install the client
+used by your application separately; ``pytest-databases`` does not add a Google Cloud Pub/Sub client dependency.
+
 Optional Database Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/supported-databases/index.rst
+++ b/docs/supported-databases/index.rst
@@ -14,6 +14,7 @@ This section provides detailed information on the supported databases, including
    sqlserver
    spanner
    bigquery
+   pubsub
    cockroachdb
    yugabyte
    mongodb

--- a/docs/supported-databases/pubsub.rst
+++ b/docs/supported-databases/pubsub.rst
@@ -1,0 +1,91 @@
+Google Pub/Sub
+==============
+
+Integration with `Google Cloud Pub/Sub <https://cloud.google.com/pubsub>`_ using Google's official
+`Pub/Sub emulator <https://cloud.google.com/pubsub/docs/emulator>`_. The fixture starts the version-pinned Google Cloud
+CLI emulator image and validates it with the ``gcloud`` tooling already present in that image. The package does not
+depend on ``google-cloud-pubsub`` or mutate Google credential environment variables.
+
+Installation
+------------
+
+Install the base package:
+
+.. code-block:: bash
+
+   pip install pytest-databases
+
+Install the Pub/Sub client used by your application separately, if it needs one.
+
+Usage
+-----
+
+Enable the plugin and pass the service metadata to your application. Standard Google clients recognize
+``PUBSUB_EMULATOR_HOST``; set it in your own fixture or application configuration so the parent test process remains
+under your control.
+
+.. code-block:: python
+
+   import pytest
+
+   from pytest_databases.docker.pubsub import PubSubService
+
+   pytest_plugins = ["pytest_databases.docker.pubsub"]
+
+
+   @pytest.fixture
+   def pubsub_environment(pubsub_service: PubSubService, monkeypatch: pytest.MonkeyPatch) -> PubSubService:
+       monkeypatch.setenv("PUBSUB_EMULATOR_HOST", pubsub_service.emulator_host)
+       monkeypatch.setenv("PUBSUB_PROJECT_ID", pubsub_service.project)
+       return pubsub_service
+
+
+   def test_publish_event(pubsub_environment: PubSubService) -> None:
+       assert pubsub_environment.emulator_host == (
+           f"{pubsub_environment.host}:{pubsub_environment.port}"
+       )
+       # Call application code configured by pubsub_environment here.
+
+The service fixture waits for both the emulator's documented ``Server started`` log and the mapped TCP endpoint. Before
+yielding, an ephemeral sidecar from the same official image creates a topic and subscription, publishes a payload, pulls
+and acknowledges it, and removes the smoke resources. No host-side Google client or credentials are involved.
+
+Available fixtures
+------------------
+
+* ``pubsub_image``: Google Cloud CLI ``577.0.0-emulators`` image. Override it to test a newer compatible release.
+* ``pubsub_project``: ``pytest-databases`` outside xdist and a worker-suffixed project under xdist.
+* ``xdist_pubsub_isolation_level``: ``database`` by default; override with ``server`` for one container per worker.
+* ``pubsub_service``: :class:`~pytest_databases.docker.pubsub.PubSubService` containing ``host``, ``port``, ``project``,
+  ``emulator_host``, and the underlying container.
+
+Parallel isolation
+------------------
+
+The default ``database`` isolation shares one emulator container and assigns each xdist worker a separate project ID.
+The emulator namespaces resources by project, so workers may use the same topic and subscription names. Override the
+isolation fixture when a test needs a separate emulator process:
+
+.. code-block:: python
+
+   import pytest
+
+
+   @pytest.fixture(scope="session")
+   def xdist_pubsub_isolation_level() -> str:
+       return "server"
+
+Limitations
+-----------
+
+The emulator is intended for local development and can differ from the production service. IAM integration, ACL checks,
+and some production features are not implemented. Data is ephemeral, and tests should not use the emulator to validate
+credentials, permissions, quotas, or production delivery guarantees.
+
+Service API
+-----------
+
+.. automodule:: pytest_databases.docker.pubsub
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/supported-databases/pubsub.rst
+++ b/docs/supported-databases/pubsub.rst
@@ -47,8 +47,8 @@ under your control.
        # Call application code configured by pubsub_environment here.
 
 The service fixture waits for both the emulator's documented ``Server started`` log and the mapped TCP endpoint. Before
-yielding, an ephemeral sidecar from the same official image creates a topic and subscription, publishes a payload, pulls
-and acknowledges it, and removes the smoke resources. No host-side Google client or credentials are involved.
+yielding, the bundled ``gcloud`` CLI creates a topic and subscription inside the emulator container, publishes a payload,
+pulls and acknowledges it, and removes the smoke resources. No host-side Google client or credentials are involved.
 
 Available fixtures
 ------------------

--- a/src/pytest_databases/docker/pubsub.py
+++ b/src/pytest_databases/docker/pubsub.py
@@ -1,13 +1,40 @@
 from __future__ import annotations
 
+import socket
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import pytest
 
 from pytest_databases.helpers import get_xdist_worker_id
 from pytest_databases.types import ServiceContainer, XdistIsolationLevel
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from docker.models.containers import Container
+
+    from pytest_databases._service import ContainerService
+
 PUBSUB_EMULATOR_IMAGE = "gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"
+PUBSUB_EMULATOR_PORT = 8085
+
+_PUBSUB_SMOKE_SCRIPT = """\
+set -eu
+topic="pytest-databases-smoke"
+subscription="pytest-databases-smoke"
+cleanup() {
+    gcloud pubsub subscriptions delete "$subscription" --quiet >/dev/null 2>&1 || true
+    gcloud pubsub topics delete "$topic" --quiet >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+gcloud pubsub topics create "$topic" --quiet
+gcloud pubsub subscriptions create "$subscription" --topic="$topic" --quiet
+gcloud pubsub topics publish "$topic" --message=pytest-databases --quiet
+payload="$(timeout 30 gcloud pubsub subscriptions pull "$subscription" --auto-ack --limit=1 --format='value(message.data)' --quiet)"
+test "$payload" = "pytest-databases"
+"""
 
 
 @dataclass
@@ -32,3 +59,82 @@ def pubsub_project() -> str:
 @pytest.fixture(scope="session")
 def xdist_pubsub_isolation_level() -> XdistIsolationLevel:
     return "database"
+
+
+def _pubsub_start_command(project: str) -> list[str]:
+    return [
+        "gcloud",
+        "beta",
+        "emulators",
+        "pubsub",
+        "start",
+        f"--host-port=0.0.0.0:{PUBSUB_EMULATOR_PORT}",
+        f"--project={project}",
+    ]
+
+
+def _is_pubsub_responsive(service: ServiceContainer) -> bool:
+    try:
+        connection = socket.create_connection((service.host, service.port), timeout=1)
+    except OSError:
+        return False
+    connection.close()
+    return True
+
+
+def _smoke_pubsub_emulator(
+    container_service: ContainerService,
+    emulator_container: Container,
+    *,
+    image: str,
+    project: str,
+) -> None:
+    container_service.run_container(
+        image,
+        ["bash", "-c", _PUBSUB_SMOKE_SCRIPT],
+        service_name="pubsub-smoke",
+        environment={
+            "CLOUDSDK_API_ENDPOINT_OVERRIDES_PUBSUB": f"http://localhost:{PUBSUB_EMULATOR_PORT}/",
+            "CLOUDSDK_AUTH_DISABLE_CREDENTIALS": "true",
+            "CLOUDSDK_CORE_PROJECT": project,
+        },
+        network_mode=f"container:{emulator_container.id}",
+        remove=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def pubsub_service(
+    container_service: ContainerService,
+    pubsub_image: str,
+    pubsub_project: str,
+    xdist_pubsub_isolation_level: XdistIsolationLevel,
+) -> Generator[PubSubService, None, None]:
+    worker_id = get_xdist_worker_id()
+    container_name = "pubsub"
+    if xdist_pubsub_isolation_level == "server" and worker_id not in {None, "master"}:
+        container_name = f"{container_name}_{worker_id}"
+
+    with container_service.run(
+        image=pubsub_image,
+        command=_pubsub_start_command(pubsub_project),
+        name=container_name,
+        container_port=PUBSUB_EMULATOR_PORT,
+        wait_for_log="Server started",
+        check=_is_pubsub_responsive,
+        timeout=60,
+        transient=xdist_pubsub_isolation_level == "server",
+    ) as service:
+        _smoke_pubsub_emulator(
+            container_service,
+            service.container,
+            image=pubsub_image,
+            project=pubsub_project,
+        )
+        yield PubSubService(
+            container=service.container,
+            host=service.host,
+            port=service.port,
+            project=pubsub_project,
+            emulator_host=f"{service.host}:{service.port}",
+        )

--- a/src/pytest_databases/docker/pubsub.py
+++ b/src/pytest_databases/docker/pubsub.py
@@ -83,24 +83,22 @@ def _is_pubsub_responsive(service: ServiceContainer) -> bool:
 
 
 def _smoke_pubsub_emulator(
-    container_service: ContainerService,
     emulator_container: Container,
     *,
-    image: str,
     project: str,
 ) -> None:
-    container_service.run_container(
-        image,
+    result = emulator_container.exec_run(
         ["bash", "-c", _PUBSUB_SMOKE_SCRIPT],
-        service_name="pubsub-smoke",
         environment={
             "CLOUDSDK_API_ENDPOINT_OVERRIDES_PUBSUB": f"http://localhost:{PUBSUB_EMULATOR_PORT}/",
             "CLOUDSDK_AUTH_DISABLE_CREDENTIALS": "true",
             "CLOUDSDK_CORE_PROJECT": project,
         },
-        network_mode=f"container:{emulator_container.id}",
-        remove=True,
     )
+    if result.exit_code != 0:
+        output = result.output.decode(errors="replace") if isinstance(result.output, bytes) else str(result.output)
+        msg = f"Pub/Sub emulator smoke check failed with exit code {result.exit_code}: {output[-2000:]}"
+        raise RuntimeError(msg)
 
 
 @pytest.fixture(scope="session")
@@ -126,9 +124,7 @@ def pubsub_service(
         transient=xdist_pubsub_isolation_level == "server",
     ) as service:
         _smoke_pubsub_emulator(
-            container_service,
             service.container,
-            image=pubsub_image,
             project=pubsub_project,
         )
         yield PubSubService(

--- a/src/pytest_databases/docker/pubsub.py
+++ b/src/pytest_databases/docker/pubsub.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from pytest_databases.helpers import get_xdist_worker_id
+from pytest_databases.types import ServiceContainer, XdistIsolationLevel
+
+PUBSUB_EMULATOR_IMAGE = "gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"
+
+
+@dataclass
+class PubSubService(ServiceContainer):
+    project: str
+    emulator_host: str
+
+
+@pytest.fixture(scope="session")
+def pubsub_image() -> str:
+    return PUBSUB_EMULATOR_IMAGE
+
+
+@pytest.fixture(scope="session")
+def pubsub_project() -> str:
+    worker_id = get_xdist_worker_id()
+    if worker_id is None or worker_id == "master":
+        return "pytest-databases"
+    return f"pytest-databases-{worker_id}"
+
+
+@pytest.fixture(scope="session")
+def xdist_pubsub_isolation_level() -> XdistIsolationLevel:
+    return "database"

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
+
+import pytest
 
 from pytest_databases.docker import pubsub
 from pytest_databases.docker.pubsub import PubSubService
 from pytest_databases.types import ServiceContainer
 
 PUBSUB_IMAGE = "gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"
+
+
+def _clear_google_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in (
+        "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "PUBSUB_EMULATOR_HOST",
+    ):
+        monkeypatch.delenv(variable, raising=False)
 
 
 def test_pubsub_service_metadata() -> None:
@@ -103,3 +116,87 @@ def test_pubsub_smoke_uses_ephemeral_gcloud_sidecar() -> None:
         "network_mode": "container:pubsub-container",
         "remove": True,
     }
+
+
+def test_plugin_imports_without_google_cloud_pubsub(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile("""
+    import builtins
+
+    def test_import() -> None:
+        original_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("google.cloud.pubsub"):
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+        try:
+            import pytest_databases.docker.pubsub
+        finally:
+            builtins.__import__ = original_import
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_pubsub_service_fixture(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_google_environment(monkeypatch)
+    pytester.makepyfile("""
+    pytest_plugins = ["pytest_databases.docker.pubsub"]
+
+    def test_service(pubsub_service) -> None:
+        assert pubsub_service.project == "pytest-databases"
+        assert pubsub_service.emulator_host == f"{pubsub_service.host}:{pubsub_service.port}"
+        assert pubsub_service.container.status == "running"
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    ("isolation_level", "expect_shared_container"),
+    [("database", True), ("server", False)],
+)
+def test_pubsub_xdist_isolation(
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+    isolation_level: str,
+    expect_shared_container: bool,
+) -> None:
+    _clear_google_environment(monkeypatch)
+    monkeypatch.setenv("PUBSUB_RECORD_DIR", str(pytester.path))
+    pytester.makepyfile(f"""
+    import json
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    pytest_plugins = ["pytest_databases.docker.pubsub"]
+
+    @pytest.fixture(scope="session")
+    def xdist_pubsub_isolation_level():
+        return {isolation_level!r}
+
+    @pytest.mark.parametrize("case", [0, 1])
+    def test_isolation(pubsub_service, case) -> None:
+        worker_id = os.environ["PYTEST_XDIST_WORKER"]
+        assert pubsub_service.project == f"pytest-databases-{{worker_id}}"
+        record = {{
+            "container_id": pubsub_service.container.id,
+            "project": pubsub_service.project,
+        }}
+        path = Path(os.environ["PUBSUB_RECORD_DIR"]) / f"pubsub-{{worker_id}}.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2", "--dist=load", "-vv")
+    result.assert_outcomes(passed=2)
+    records = [json.loads(path.read_text(encoding="utf-8")) for path in pytester.path.glob("pubsub-gw*.json")]
+    assert len(records) == 2
+    assert len({record["project"] for record in records}) == 2
+    container_count = len({record["container_id"] for record in records})
+    assert container_count == (1 if expect_shared_container else 2)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pytest_databases.docker.pubsub import PubSubService
+from pytest_databases.types import ServiceContainer
+
+PUBSUB_IMAGE = "gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-emulators"
+
+
+def test_pubsub_service_metadata() -> None:
+    service = PubSubService(
+        container=MagicMock(),
+        host="127.0.0.1",
+        port=8085,
+        project="pytest-databases",
+        emulator_host="127.0.0.1:8085",
+    )
+
+    assert isinstance(service, ServiceContainer)
+    assert service.project == "pytest-databases"
+    assert service.emulator_host == f"{service.host}:{service.port}"
+
+
+def test_pubsub_contract_fixtures(pytester) -> None:
+    pytester.makepyfile(f"""
+    pytest_plugins = ["pytest_databases.docker.pubsub"]
+
+    def test_contract(pubsub_image, pubsub_project, xdist_pubsub_isolation_level) -> None:
+        assert pubsub_image == {PUBSUB_IMAGE!r}
+        assert pubsub_project == "pytest-databases"
+        assert xdist_pubsub_isolation_level == "database"
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)
+
+
+def test_pubsub_project_is_worker_scoped(pytester, monkeypatch) -> None:
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+    pytester.makepyfile("""
+    pytest_plugins = ["pytest_databases.docker.pubsub"]
+
+    def test_project(pubsub_project) -> None:
+        assert pubsub_project == "pytest-databases-gw2"
+    """)
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
+    result.assert_outcomes(passed=1)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -22,6 +22,11 @@ def _clear_google_environment(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(variable, raising=False)
 
 
+def _clear_xdist_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in ("PYTEST_XDIST_TESTRUNUID", "PYTEST_XDIST_WORKER", "PYTEST_XDIST_WORKER_COUNT"):
+        monkeypatch.delenv(variable, raising=False)
+
+
 def test_pubsub_service_metadata() -> None:
     service = PubSubService(
         container=MagicMock(),
@@ -36,7 +41,8 @@ def test_pubsub_service_metadata() -> None:
     assert service.emulator_host == f"{service.host}:{service.port}"
 
 
-def test_pubsub_contract_fixtures(pytester) -> None:
+def test_pubsub_contract_fixtures(pytester, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_xdist_environment(monkeypatch)
     pytester.makepyfile(f"""
     pytest_plugins = ["pytest_databases.docker.pubsub"]
 
@@ -51,6 +57,7 @@ def test_pubsub_contract_fixtures(pytester) -> None:
 
 
 def test_pubsub_project_is_worker_scoped(pytester, monkeypatch) -> None:
+    _clear_xdist_environment(monkeypatch)
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
     pytester.makepyfile("""
     pytest_plugins = ["pytest_databases.docker.pubsub"]
@@ -88,34 +95,38 @@ def test_pubsub_readiness_requires_tcp(mocker) -> None:
     assert pubsub._is_pubsub_responsive(service) is False
 
 
-def test_pubsub_smoke_uses_ephemeral_gcloud_sidecar() -> None:
-    container_service = MagicMock()
-    emulator_container = MagicMock(id="pubsub-container")
+def test_pubsub_smoke_uses_bundled_gcloud() -> None:
+    emulator_container = MagicMock()
+    emulator_container.exec_run.return_value = MagicMock(exit_code=0, output=b"")
 
     pubsub._smoke_pubsub_emulator(
-        container_service,
         emulator_container,
-        image=PUBSUB_IMAGE,
         project="pytest-databases-gw2",
     )
 
-    args, kwargs = container_service.run_container.call_args
-    assert args[0] == PUBSUB_IMAGE
-    assert args[1][:2] == ["bash", "-c"]
-    assert "gcloud pubsub topics create" in args[1][2]
-    assert "gcloud pubsub subscriptions create" in args[1][2]
-    assert "gcloud pubsub topics publish" in args[1][2]
-    assert "gcloud pubsub subscriptions pull" in args[1][2]
+    args, kwargs = emulator_container.exec_run.call_args
+    assert args[0][:2] == ["bash", "-c"]
+    assert "gcloud pubsub topics create" in args[0][2]
+    assert "gcloud pubsub subscriptions create" in args[0][2]
+    assert "gcloud pubsub topics publish" in args[0][2]
+    assert "gcloud pubsub subscriptions pull" in args[0][2]
     assert kwargs == {
-        "service_name": "pubsub-smoke",
         "environment": {
             "CLOUDSDK_API_ENDPOINT_OVERRIDES_PUBSUB": "http://localhost:8085/",
             "CLOUDSDK_AUTH_DISABLE_CREDENTIALS": "true",
             "CLOUDSDK_CORE_PROJECT": "pytest-databases-gw2",
         },
-        "network_mode": "container:pubsub-container",
-        "remove": True,
     }
+
+
+def test_pubsub_smoke_reports_bounded_failure() -> None:
+    emulator_container = MagicMock()
+    emulator_container.exec_run.return_value = MagicMock(exit_code=7, output=b"x" * 3000)
+
+    with pytest.raises(RuntimeError, match="exit code 7") as exc_info:
+        pubsub._smoke_pubsub_emulator(emulator_container, project="pytest-databases")
+
+    assert len(str(exc_info.value)) < 2100
 
 
 def test_plugin_imports_without_google_cloud_pubsub(pytester: pytest.Pytester) -> None:
@@ -143,6 +154,7 @@ def test_plugin_imports_without_google_cloud_pubsub(pytester: pytest.Pytester) -
 
 def test_pubsub_service_fixture(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_google_environment(monkeypatch)
+    _clear_xdist_environment(monkeypatch)
     pytester.makepyfile("""
     pytest_plugins = ["pytest_databases.docker.pubsub"]
 
@@ -160,6 +172,7 @@ def test_pubsub_service_fixture(pytester: pytest.Pytester, monkeypatch: pytest.M
     ("isolation_level", "expect_shared_container"),
     [("database", True), ("server", False)],
 )
+@pytest.mark.xdist_group(name="pubsub_nested_xdist")
 def test_pubsub_xdist_isolation(
     pytester: pytest.Pytester,
     monkeypatch: pytest.MonkeyPatch,
@@ -167,6 +180,7 @@ def test_pubsub_xdist_isolation(
     expect_shared_container: bool,
 ) -> None:
     _clear_google_environment(monkeypatch)
+    _clear_xdist_environment(monkeypatch)
     monkeypatch.setenv("PUBSUB_RECORD_DIR", str(pytester.path))
     pytester.makepyfile(f"""
     import json

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from pytest_databases.docker import pubsub
 from pytest_databases.docker.pubsub import PubSubService
 from pytest_databases.types import ServiceContainer
 
@@ -47,3 +48,58 @@ def test_pubsub_project_is_worker_scoped(pytester, monkeypatch) -> None:
 
     result = pytester.runpytest_subprocess("-p", "pytest_databases", "-vv")
     result.assert_outcomes(passed=1)
+
+
+def test_pubsub_start_command() -> None:
+    assert pubsub._pubsub_start_command("pytest-databases-gw2") == [
+        "gcloud",
+        "beta",
+        "emulators",
+        "pubsub",
+        "start",
+        "--host-port=0.0.0.0:8085",
+        "--project=pytest-databases-gw2",
+    ]
+
+
+def test_pubsub_readiness_requires_tcp(mocker) -> None:
+    service = ServiceContainer(container=MagicMock(), host="127.0.0.1", port=8085)
+    connection = MagicMock()
+    create_connection = mocker.patch.object(pubsub.socket, "create_connection", return_value=connection)
+
+    assert pubsub._is_pubsub_responsive(service) is True
+    create_connection.assert_called_once_with(("127.0.0.1", 8085), timeout=1)
+    connection.close.assert_called_once_with()
+
+    create_connection.side_effect = OSError("not listening")
+    assert pubsub._is_pubsub_responsive(service) is False
+
+
+def test_pubsub_smoke_uses_ephemeral_gcloud_sidecar() -> None:
+    container_service = MagicMock()
+    emulator_container = MagicMock(id="pubsub-container")
+
+    pubsub._smoke_pubsub_emulator(
+        container_service,
+        emulator_container,
+        image=PUBSUB_IMAGE,
+        project="pytest-databases-gw2",
+    )
+
+    args, kwargs = container_service.run_container.call_args
+    assert args[0] == PUBSUB_IMAGE
+    assert args[1][:2] == ["bash", "-c"]
+    assert "gcloud pubsub topics create" in args[1][2]
+    assert "gcloud pubsub subscriptions create" in args[1][2]
+    assert "gcloud pubsub topics publish" in args[1][2]
+    assert "gcloud pubsub subscriptions pull" in args[1][2]
+    assert kwargs == {
+        "service_name": "pubsub-smoke",
+        "environment": {
+            "CLOUDSDK_API_ENDPOINT_OVERRIDES_PUBSUB": "http://localhost:8085/",
+            "CLOUDSDK_AUTH_DISABLE_CREDENTIALS": "true",
+            "CLOUDSDK_CORE_PROJECT": "pytest-databases-gw2",
+        },
+        "network_mode": "container:pubsub-container",
+        "remove": True,
+    }


### PR DESCRIPTION
## Summary\n\n- add the official Google Pub/Sub emulator with bundled gcloud lifecycle checks\n- cover topic, subscription, publish, pull, acknowledgement, cleanup, and xdist isolation without a Python client\n- run smoke validation inside the emulator to avoid redundant sidecars\n\n## Validation\n\n- serial provider tests: 11 passed\n- outer xdist provider tests: 11 passed\n- Ruff, mypy, pyright, slotscheck, and docs passed\n- selector: 1 provider job, 1 image pull\n- no Google client dependency or lockfile change\n\nPart of #150.