### PR TITLE
feat: add clientless RabbitMQ service

### DIFF
--- a/.github/ci/provider-groups.json
+++ b/.github/ci/provider-groups.json
@@ -173,6 +173,12 @@
       ],
       "docs_globs": ["docs/supported-databases/redis.rst"]
     },
+    "rabbitmq": {
+      "source_globs": ["src/pytest_databases/docker/rabbitmq.py"],
+      "test_paths": ["tests/test_rabbitmq.py"],
+      "images": ["rabbitmq:4.3-management"],
+      "docs_globs": ["docs/supported-databases/rabbitmq.rst"]
+    },
     "rustfs": {
       "source_globs": ["src/pytest_databases/docker/rustfs.py"],
       "test_paths": ["tests/test_rustfs.py", "tests/test_rustfs_config.py"],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Added
 * Session-owned container labels/names and a daemon-scoped creation lock that prevents cross-session cleanup/reuse and
   rootless dynamic-port allocation races. Closes `gh-152 <https://github.com/litestar-org/pytest-databases/issues/152>`_.
 * Explicit ``cleanup_stale_containers()`` recovery for containers left by a hard-killed pytest process.
+* Clientless RabbitMQ 4.3 service fixtures with worker-specific virtual-host or broker isolation. Closes
+  `gh-150 <https://github.com/litestar-org/pytest-databases/issues/150>`_.
 
 0.19.0 (2026-05-23)
 -------------------

--- a/docs/supported-databases/index.rst
+++ b/docs/supported-databases/index.rst
@@ -18,6 +18,7 @@ This section provides detailed information on the supported databases, including
    yugabyte
    mongodb
    gizmosql
+   rabbitmq
    redis
    valkey
    elasticsearch

--- a/docs/supported-databases/rabbitmq.rst
+++ b/docs/supported-databases/rabbitmq.rst
@@ -1,0 +1,59 @@
+RabbitMQ
+========
+
+Integration with `RabbitMQ 4.3 <https://www.rabbitmq.com/docs>`_ using the official
+``rabbitmq:4.3-management`` container image.
+
+Installation
+------------
+
+Install ``pytest-databases`` and the AMQP client used by your application. The fixture itself does not install or
+import an AMQP client:
+
+.. code-block:: bash
+
+   pip install pytest-databases pika
+
+Readiness and the pytest-databases smoke tests use ``rabbitmq-diagnostics`` and ``rabbitmqadmin`` from inside the
+container. Only the AMQP port is published; the management port remains internal to the test container.
+
+Usage example
+-------------
+
+.. code-block:: python
+
+   import pika
+
+   from pytest_databases.docker.rabbitmq import RabbitMQService
+
+   pytest_plugins = ["pytest_databases.docker.rabbitmq"]
+
+
+   def test_publish(rabbitmq_service: RabbitMQService) -> None:
+       connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_service.amqp_url))
+       channel = connection.channel()
+       channel.queue_declare(queue="example", durable=True)
+       channel.basic_publish(exchange="", routing_key="example", body=b"message")
+       method, _, body = channel.basic_get(queue="example", auto_ack=True)
+       assert method is not None
+       assert body == b"message"
+       connection.close()
+
+Available fixtures
+------------------
+
+* ``rabbitmq_image``: Container image, defaulting to ``rabbitmq:4.3-management``.
+* ``rabbitmq_username`` and ``rabbitmq_password``: Non-guest test credentials.
+* ``rabbitmq_vhost``: Worker-specific virtual host with default xdist isolation.
+* ``rabbitmq_host`` and ``rabbitmq_port``: Published AMQP endpoint.
+* ``rabbitmq_service``: ``RabbitMQService`` with host, port, container, credentials, virtual host, and ``amqp_url``.
+* ``xdist_rabbitmq_isolation_level``: ``"database"`` for one virtual host per worker, or ``"server"`` for one broker
+  per worker.
+
+Service API
+-----------
+
+.. automodule:: pytest_databases.docker.rabbitmq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/pytest_databases/docker/rabbitmq.py
+++ b/src/pytest_databases/docker/rabbitmq.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+import pytest
+from docker.errors import APIError
+
+from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer, XdistIsolationLevel
+
+_RABBITMQ_COMMAND = (
+    "mkdir -p /run/pytest-databases-rabbitmq && "
+    "chown rabbitmq:rabbitmq /run/pytest-databases-rabbitmq && exec gosu rabbitmq rabbitmq-server"
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+
+    from docker.models.containers import Container
+
+    from pytest_databases._service import ContainerService
+
+
+def _output_to_bytes(output: bytes | str | Iterator[bytes]) -> bytes:
+    if isinstance(output, bytes):
+        return output
+    if isinstance(output, str):
+        return output.encode()
+    return b"".join(output)
+
+
+def _exec(container: Container, *args: str) -> tuple[int, bytes]:
+    result = container.exec_run(list(args))
+    return result.exit_code if result.exit_code is not None else -1, _output_to_bytes(result.output)
+
+
+def _rabbitmq_responsive(service: ServiceContainer) -> bool:
+    try:
+        running_code, _ = _exec(service.container, "rabbitmq-diagnostics", "-q", "check_running")
+        listener_code, _ = _exec(service.container, "rabbitmq-diagnostics", "-q", "check_port_listener", "5672")
+    except APIError:
+        return False
+    return running_code == 0 and listener_code == 0
+
+
+def _ensure_vhost(container: Container, *, username: str, vhost: str) -> None:
+    list_code, output = _exec(container, "rabbitmqctl", "-q", "list_vhosts", "name", "--no-table-headers")
+    if list_code != 0:
+        message = output.decode(errors="replace")
+        raise RuntimeError(message)
+    if vhost not in output.decode().splitlines():
+        add_code, add_output = _exec(container, "rabbitmqctl", "-q", "add_vhost", vhost)
+        if add_code != 0:
+            message = add_output.decode(errors="replace")
+            raise RuntimeError(message)
+    permission_code, permission_output = _exec(
+        container,
+        "rabbitmqctl",
+        "-q",
+        "set_permissions",
+        "-p",
+        vhost,
+        username,
+        ".*",
+        ".*",
+        ".*",
+    )
+    if permission_code != 0:
+        message = permission_output.decode(errors="replace")
+        raise RuntimeError(message)
+
+
+@dataclasses.dataclass
+class RabbitMQService(ServiceContainer):
+    """Connection metadata for a RabbitMQ AMQP service."""
+
+    username: str
+    password: str
+    vhost: str
+
+    @property
+    def amqp_url(self) -> str:
+        """Return an AMQP URL with escaped credentials and virtual host."""
+        username = quote(self.username, safe="")
+        password = quote(self.password, safe="")
+        vhost = quote(self.vhost, safe="")
+        return f"amqp://{username}:{password}@{self.host}:{self.port}/{vhost}"
+
+
+@pytest.fixture(scope="session")
+def xdist_rabbitmq_isolation_level() -> XdistIsolationLevel:
+    return "database"
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_image() -> str:
+    return "rabbitmq:4.3-management"
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_username() -> str:
+    return "pytest-databases"
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_password() -> str:
+    return "pytest-databases-secret"
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_vhost(xdist_rabbitmq_isolation_level: XdistIsolationLevel) -> str:
+    worker_num = get_xdist_worker_num()
+    if worker_num is not None and xdist_rabbitmq_isolation_level == "database":
+        return f"pytest_databases_{worker_num}"
+    return "pytest_databases"
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_host(rabbitmq_service: RabbitMQService) -> str:
+    return rabbitmq_service.host
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_port(rabbitmq_service: RabbitMQService) -> int:
+    return rabbitmq_service.port
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_service(
+    container_service: ContainerService,
+    rabbitmq_image: str,
+    rabbitmq_username: str,
+    rabbitmq_password: str,
+    rabbitmq_vhost: str,
+    xdist_rabbitmq_isolation_level: XdistIsolationLevel,
+) -> Generator[RabbitMQService, None, None]:
+    worker_num = get_xdist_worker_num()
+    name = "rabbitmq"
+    if worker_num is not None and xdist_rabbitmq_isolation_level == "server":
+        name = f"rabbitmq_{worker_num + 1}"
+
+    with container_service.run(
+        rabbitmq_image,
+        container_port=5672,
+        name=name,
+        command=["bash", "-c", _RABBITMQ_COMMAND],
+        check=_rabbitmq_responsive,
+        wait_for_log="Server startup complete",
+        env={
+            "RABBITMQ_DEFAULT_USER": rabbitmq_username,
+            "RABBITMQ_DEFAULT_PASS": rabbitmq_password,
+            "RABBITMQ_DEFAULT_VHOST": "pytest_databases",
+            "RABBITMQ_ERLANG_COOKIE": "pytest-databases-erlang-cookie",
+            "RABBITMQ_MNESIA_BASE": "/run/pytest-databases-rabbitmq/mnesia",
+            "HOME": "/run/pytest-databases-rabbitmq",
+        },
+        timeout=60,
+        transient=xdist_rabbitmq_isolation_level == "server",
+    ) as service:
+        _ensure_vhost(service.container, username=rabbitmq_username, vhost=rabbitmq_vhost)
+        yield RabbitMQService(
+            container=service.container,
+            host=service.host,
+            port=service.port,
+            username=rabbitmq_username,
+            password=rabbitmq_password,
+            vhost=rabbitmq_vhost,
+        )

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+    from pytest_databases.docker.rabbitmq import RabbitMQService
+
+pytest_plugins = ["pytest_databases.docker.rabbitmq"]
+
+
+RABBITMQ_TEST_HELPERS = """
+def run_rabbitmqadmin(service, *args):
+    result = service.container.exec_run([
+        "rabbitmqadmin",
+        "--username", service.username,
+        "--password", service.password,
+        "--vhost", service.vhost,
+        "--non-interactive",
+        *args,
+    ])
+    output = result.output if isinstance(result.output, bytes) else b"".join(result.output)
+    assert result.exit_code == 0, output.decode(errors="replace")
+    return output.decode(errors="replace")
+
+
+def assert_round_trip(service, queue):
+    run_rabbitmqadmin(service, "declare", "queue", "--name", queue, "--durable", "true")
+    run_rabbitmqadmin(
+        service,
+        "publish", "message",
+        "--routing-key", queue,
+        "--payload", "pytest-databases-message",
+    )
+    output = run_rabbitmqadmin(service, "get", "messages", "--queue", queue)
+    assert "pytest-databases-message" in output
+"""
+
+
+def _run_rabbitmqadmin(service: RabbitMQService, *args: str) -> str:
+    result = service.container.exec_run([
+        "rabbitmqadmin",
+        "--username",
+        service.username,
+        "--password",
+        service.password,
+        "--vhost",
+        service.vhost,
+        "--non-interactive",
+        *args,
+    ])
+    output = result.output if isinstance(result.output, bytes) else b"".join(result.output)
+    assert result.exit_code == 0, output.decode(errors="replace")
+    return output.decode(errors="replace")
+
+
+def _assert_round_trip(service: RabbitMQService, queue: str) -> None:
+    _run_rabbitmqadmin(service, "declare", "queue", "--name", queue, "--durable", "true")
+    _run_rabbitmqadmin(
+        service,
+        "publish",
+        "message",
+        "--routing-key",
+        queue,
+        "--payload",
+        "pytest-databases-message",
+    )
+    assert "pytest-databases-message" in _run_rabbitmqadmin(service, "get", "messages", "--queue", queue)
+
+
+def test_rabbitmq_service_is_clientless_and_ready(rabbitmq_service: RabbitMQService) -> None:
+    assert rabbitmq_service.host == "127.0.0.1"
+    assert rabbitmq_service.port > 0
+    assert rabbitmq_service.amqp_url.startswith("amqp://pytest-databases:")
+    _assert_round_trip(rabbitmq_service, "clientless-smoke")
+
+
+def test_rabbitmq_xdist_vhost_isolation(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(f"""
+from pytest_databases.docker.rabbitmq import RabbitMQService
+from pytest_databases.helpers import get_xdist_worker_num
+
+pytest_plugins = ["pytest_databases.docker.rabbitmq"]
+
+{RABBITMQ_TEST_HELPERS}
+
+def check_isolation(service):
+    assert service.vhost == f"pytest_databases_{{get_xdist_worker_num()}}"
+    assert_round_trip(service, "same-queue")
+
+def test_one(rabbitmq_service: RabbitMQService) -> None:
+    check_isolation(rabbitmq_service)
+
+def test_two(rabbitmq_service: RabbitMQService) -> None:
+    check_isolation(rabbitmq_service)
+""")
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")
+    result.assert_outcomes(passed=2)
+
+
+def test_rabbitmq_xdist_server_isolation(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(f"""
+import pytest
+from pytest_databases.docker.rabbitmq import RabbitMQService
+
+pytest_plugins = ["pytest_databases.docker.rabbitmq"]
+
+{RABBITMQ_TEST_HELPERS}
+
+@pytest.fixture(scope="session")
+def xdist_rabbitmq_isolation_level():
+    return "server"
+
+def check_isolation(service):
+    assert service.vhost == "pytest_databases"
+    assert_round_trip(service, "same-queue")
+
+def test_one(rabbitmq_service: RabbitMQService) -> None:
+    check_isolation(rabbitmq_service)
+
+def test_two(rabbitmq_service: RabbitMQService) -> None:
+    check_isolation(rabbitmq_service)
+""")
+
+    result = pytester.runpytest_subprocess("-p", "pytest_databases", "-n", "2")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Summary\n\n- add RabbitMQ 4.3 fixtures using bundled rabbitmq-diagnostics, rabbitmqctl, and rabbitmqadmin\n- expose custom credentials and AMQP URL with per-worker virtual-host or broker isolation\n- keep the management port internal and register one-provider selective CI ownership\n\n## Validation\n\n- provider tests: 3 passed\n- Ruff, mypy, pyright, and docs passed\n- selector: 1 provider job, 1 image pull\n- no AMQP Python client dependency or lockfile change\n\nPart of #150.