### PR TITLE
feat: scope automatic container cleanup to a namespace instead of the whole host

### DIFF
--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -11,6 +11,7 @@ These variables apply globally to the Docker setup:
 *   ``SKIP_DOCKER_COMPOSE=True``: If set, skip trying to manage database containers via Docker Compose. Useful if you manage services externally. (Default: "False")
 *   ``USE_LEGACY_DOCKER_COMPOSE=True``: If set, forces the use of the older ``docker-compose`` command instead of ``docker compose``. (Default: "False")
 *   ``DOCKER_HOST``: Specifies the host where the Docker daemon is running and where services will be exposed. (Default: "127.0.0.1")
+*   ``PYTEST_DATABASES_NAMESPACE``: If set, the Docker container will be labelled with the provided namespace. This allows multiple processes to run pytest using this library without any concurrency issues when starting/stopping the containers.
 
 Database-Specific Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pytest_databases/_service.py
+++ b/src/pytest_databases/_service.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import filelock
 import pytest
+from docker import DockerClient
 from docker.errors import APIError, ImageNotFound
 from typing_extensions import Self
 
-from docker import DockerClient
-from pytest_databases.helpers import get_xdist_worker_id
+from pytest_databases.helpers import get_xdist_worker_id, simple_string_hash
 from pytest_databases.types import ServiceContainer
 
 if TYPE_CHECKING:
@@ -56,10 +56,15 @@ def get_docker_client() -> DockerClient:
     return DockerClient.from_env(environment=env)
 
 
-def _stop_all_containers(client: DockerClient) -> None:
+def _compute_namespace(session: pytest.Session) -> str:
+    override = os.environ.get("PYTEST_DATABASES_NAMESPACE", "").strip()
+    return override if override else simple_string_hash(str(session.config.rootpath))
+
+
+def _stop_all_containers(client: DockerClient, *, label: str = "pytest_databases") -> None:
     containers: list[Container] = client.containers.list(
         all=True,
-        filters={"label": "pytest_databases"},
+        filters={"label": label},
         ignore_removed=True,
     )
     for container in containers:
@@ -88,10 +93,12 @@ class DockerService(AbstractContextManager):
         client: DockerClient,
         tmp_path: pathlib.Path,
         session: pytest.Session,
+        namespace: str,
     ) -> None:
         self._client = client
         self._tmp_path = tmp_path
         self._session = session
+        self._namespace = namespace
         self._is_xdist = get_xdist_worker_id() is not None
 
     def __enter__(self) -> Self:
@@ -100,9 +107,9 @@ class DockerService(AbstractContextManager):
             with filelock.FileLock(ctrl_file.with_suffix(".lock")):
                 if not ctrl_file.exists():
                     ctrl_file.touch()
-                    self._stop_all_containers()
+                    self._stop_namespace_containers()
         else:
-            self._stop_all_containers()
+            self._stop_namespace_containers()
         return self
 
     def __exit__(
@@ -113,7 +120,13 @@ class DockerService(AbstractContextManager):
         __traceback: TracebackType | None,
     ) -> None:
         if not self._is_xdist:
-            self._stop_all_containers()
+            self._stop_namespace_containers()
+
+    def _stop_namespace_containers(self) -> None:
+        _stop_all_containers(self._client, label=f"pytest_databases_namespace={self._namespace}")
+
+    def container_name(self, name: str) -> str:
+        return f"pytest_databases_{name}_{self._namespace}"
 
     def _get_container(self, name: str) -> Container | None:
         containers = self._client.containers.list(
@@ -125,9 +138,6 @@ class DockerService(AbstractContextManager):
         if containers:
             return containers[0]
         return None
-
-    def _stop_all_containers(self) -> None:
-        _stop_all_containers(self._client)
 
     @contextmanager
     def run(
@@ -162,7 +172,7 @@ class DockerService(AbstractContextManager):
         if platform is not None:
             platform_kwarg = {"platform": platform}
 
-        name = f"pytest_databases_{name}"
+        name = self.container_name(name)
         lock = filelock.FileLock(self._tmp_path / name) if self._is_xdist else contextlib.nullcontext()
         with lock:
             container = self._get_container(name)
@@ -188,7 +198,10 @@ class DockerService(AbstractContextManager):
                     detach=True,
                     remove=True,
                     ports={container_port: host_port},  # pyright: ignore[reportArgumentType]
-                    labels=["pytest_databases"],
+                    labels={
+                        "pytest_databases": "",
+                        "pytest_databases_namespace": self._namespace,
+                    },
                     name=name,
                     environment=env,
                     ulimits=ulimits,
@@ -281,16 +294,23 @@ def docker_client() -> Generator[DockerClient, None, None]:
 
 
 @pytest.fixture(scope="session")
+def docker_service_namespace(request: pytest.FixtureRequest) -> str:
+    return _compute_namespace(request.session)
+
+
+@pytest.fixture(scope="session")
 def docker_service(
     docker_client: DockerClient,
     tmp_path_factory: pytest.TempPathFactory,
     request: pytest.FixtureRequest,
+    docker_service_namespace: str,
 ) -> Generator[DockerService, None, None]:
     tmp_path = _get_base_tmp_path(tmp_path_factory)
     with DockerService(
         client=docker_client,
         tmp_path=tmp_path,
         session=request.session,
+        namespace=docker_service_namespace,
     ) as service:
         yield service
 
@@ -316,4 +336,5 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> Generator[
             # if we're running on xdist, delete the ctrl file, telling the deamon proc
             # to stop all running containers.
             # when not running on xdist, containers are stopped by the service itself
-            _stop_all_containers(get_docker_client())
+            namespace = _compute_namespace(session)
+            _stop_all_containers(get_docker_client(), label=f"pytest_databases_namespace={namespace}")

--- a/src/pytest_databases/docker/dolt.py
+++ b/src/pytest_databases/docker/dolt.py
@@ -68,7 +68,7 @@ def _provide_dolt_service(
     database: str,
 ) -> Generator[DoltService, None, None]:
     def check(_service: ServiceContainer) -> bool:
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         container = docker_service._get_container(container_name)
         if not container:
             return False
@@ -108,7 +108,7 @@ def _provide_dolt_service(
         # Ensure the worker-specific database exists and permissions are correct.
         # Grant global privileges to the app user so tests can create databases
         # if needed, matching the MySQL/MariaDB pattern.
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         setup_sql = (
             f"CREATE DATABASE IF NOT EXISTS {db_name}; GRANT ALL PRIVILEGES ON *.* TO '{user}'@'%'; FLUSH PRIVILEGES;"
         )

--- a/src/pytest_databases/docker/mariadb.py
+++ b/src/pytest_databases/docker/mariadb.py
@@ -67,7 +67,7 @@ def _provide_mariadb_service(
     database: str,
 ) -> Generator[MariaDBService, None, None]:
     def check(_service: ServiceContainer) -> bool:
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         container = docker_service._get_container(container_name)
         if not container:
             return False
@@ -108,7 +108,7 @@ def _provide_mariadb_service(
         # mariadb has fully provisioned the app user with the @'%' grant. Verify
         # the app user can actually reach db_name from any host before yielding,
         # otherwise tests race into 'Host not allowed' / 'access denied'.
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         container = docker_service._get_container(container_name)
         if container is None:
             msg = f"MariaDB container {container_name!r} disappeared after startup"

--- a/src/pytest_databases/docker/mysql.py
+++ b/src/pytest_databases/docker/mysql.py
@@ -73,7 +73,7 @@ def _provide_mysql_service(
     database: str,
 ) -> Generator[MySQLService, None, None]:
     def check(_service: ServiceContainer) -> bool:
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         container = docker_service._get_container(container_name)
         if not container:
             return False
@@ -115,7 +115,7 @@ def _provide_mysql_service(
         # before mysql has finished provisioning the app user and applying our
         # post-start grants. Verify the app user can actually reach db_name
         # before yielding so tests don't race the fixture into 'access denied'.
-        container_name = f"pytest_databases_{name}"
+        container_name = docker_service.container_name(name)
         container = docker_service._get_container(container_name)
         if container is None:
             msg = f"MySQL container {container_name!r} disappeared after startup"

--- a/src/pytest_databases/docker/yugabyte.py
+++ b/src/pytest_databases/docker/yugabyte.py
@@ -250,7 +250,7 @@ def yugabyte_service(
     yugabyte_database: str,
 ) -> Generator[YugabyteService, None, None]:
     def yugabyte_responsive(_service: ServiceContainer) -> bool:
-        container = docker_service._get_container(f"pytest_databases_{container_name}")
+        container = docker_service._get_container(docker_service.container_name(container_name))
         if container is None:
             return False
         exit_code, output = _exec_ysqlsh(container, "SELECT 1")
@@ -276,7 +276,7 @@ def yugabyte_service(
         timeout=120,
         pause=1.0,
     ) as service:
-        container = docker_service._get_container(f"pytest_databases_{container_name}")
+        container = docker_service._get_container(docker_service.container_name(container_name))
         if container is None:
             msg = f"Yugabyte container {container_name!r} disappeared after startup"
             raise RuntimeError(msg)


### PR DESCRIPTION
## Description

DockerService's stop-all-containers on session start/end previously targeted every container labeled `pytest_databases` globally - across every project and every concurrently-running pytest process on the Docker host. Two unrelated projects, or two independent pytest invocations against the same project, would tear down each other's containers.

Every container is now named and labeled with a `docker_service_namespace` (new fixture, override via PYTEST_DATABASES_NAMESPACE), defaulting to a hash of the pytest rootdir so out-of-the-box behavior is unchanged: one shared, always-fresh container per project, same as before. Setting the namespace explicitly (e.g. per feature/test suite) now gets that suite its own isolated container and database, safe to run concurrently with other namespaces.

Also introduces `DockerService.container_name()` as the single source of truth for the namespaced container name, and routes dolt/mysql/mariadb/yugabyte's own duplicated name-lookup logic through it so they stay in sync.

----

The above description was written by an LLM and the code edits were guided by an LLM.
